### PR TITLE
Use error-chain crate for internal error management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bencher"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +203,14 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "error-chain"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +249,7 @@ dependencies = [
  "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "graphannis-malloc_size_of 0.0.1",
@@ -560,6 +590,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +844,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
+"checksum backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "bff67d0c06556c0b8e6b5f090f0eac52d950d9dfd1d35ba04e4ca3543eaf6a7e"
 "checksum bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
 "checksum bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9f2fb9e29e72fd6bc12071533d5dc7664cb01480c59406f656d7ac25c7bd8ff7"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
@@ -829,6 +866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum encode_unicode 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "28d65f1f5841ef7c6792861294b72beda34c664deb8be27970f36c306b7da1ce"
 "checksum encode_unicode 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7dda4963a6de8b990d05ae23b6d766dde2c65e84e35b297333d137535c65a212"
+"checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
@@ -869,6 +907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5bbbea44c5490a1e84357ff28b7d518b4619a159fed5d25f6c1de2d19cc42814"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustyline 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "00b06ac9c8e8e3e83b33d175d39a9f7b6c2c930c82990593719c8e48788ae2d9"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ fxhash = "0.2"
 rayon = "1.0"
 sys-info = "0.5"
 fs2 = "0.4"
+error-chain = "0.12"
 
 graphannis-malloc_size_of = { path = "ext/malloc_size_of", version = "0.0.1"}
 graphannis-malloc_size_of_derive = { path = "ext/malloc_size_of_derive", version = "0.0.1" }

--- a/src/api/corpusstorage.rs
+++ b/src/api/corpusstorage.rs
@@ -1304,7 +1304,7 @@ impl CorpusStorage {
     }
 
     pub fn apply_update(&self, corpus_name: &str, update: &mut GraphUpdate) -> Result<()> {
-        let db_entry = self.get_loaded_entry(corpus_name, true)?;
+        let db_entry = self.get_loaded_entry(corpus_name, true).chain_err(|| format!("Could not get loaded entry for corpus {}", corpus_name))?;
         {
             let mut lock = db_entry.write().unwrap();
             let db: &mut GraphDB = get_write_or_error(&mut lock)?;

--- a/src/bin/annis.rs
+++ b/src/bin/annis.rs
@@ -17,10 +17,10 @@ use rustyline::completion::{Completer, FilenameCompleter};
 use simplelog::{LevelFilter, SimpleLogger, TermLogger};
 use graphannis::relannis;
 use std::path::{Path, PathBuf};
+use graphannis::errors::*;
 use graphannis::StringID;
 use graphannis::api::corpusstorage::CorpusStorage;
 use graphannis::api::corpusstorage::CorpusInfo;
-use graphannis::api::corpusstorage::Error;
 use graphannis::api::corpusstorage::LoadStatus;
 use graphannis::api::corpusstorage::ResultOrder;
 use std::collections::BTreeSet;
@@ -65,7 +65,7 @@ impl CommandCompleter {
 }
 
 impl Completer for CommandCompleter {
-    fn complete(&self, line: &str, pos: usize) -> Result<(usize, Vec<String>), ReadlineError> {
+    fn complete(&self, line: &str, pos: usize) -> std::result::Result<(usize, Vec<String>), ReadlineError> {
         
         // check for more specialized completers
         if line.starts_with("import ") {
@@ -107,7 +107,7 @@ struct AnnisRunner {
 }
 
 impl AnnisRunner {
-    pub fn new(data_dir: &Path) -> Result<AnnisRunner, Error> {
+    pub fn new(data_dir: &Path) -> Result<AnnisRunner> {
         Ok(AnnisRunner {
             storage: CorpusStorage::new_auto_cache_size(data_dir, false)?,
             current_corpus: None,

--- a/src/capi/error.rs
+++ b/src/capi/error.rs
@@ -2,17 +2,15 @@ use std::ffi::CString;
 use libc::c_char;
 use std;
 use log;
-use graphdb;
-use api;
-use relannis;
+use errors;
 
 pub struct Error {
     msg: CString,
 }
 
 
-impl From<api::corpusstorage::Error> for Error {
-    fn from(e: api::corpusstorage::Error) -> Error {
+impl From<errors::Error> for Error {
+    fn from(e: errors::Error) -> Error {
         let err = if let Ok(error_msg) = CString::new(String::from(format!("{:?}", e))) {
             Error {
                 msg: error_msg,
@@ -27,37 +25,6 @@ impl From<api::corpusstorage::Error> for Error {
     }
 }
 
-impl From<relannis::Error> for Error {
-    fn from(e: relannis::Error) -> Error {
-        let err = if let Ok(error_msg) = CString::new(String::from(format!("{:?}", e))) {
-            Error {
-                msg: error_msg,
-            }
-        } else {
-            // meta-error
-            Error {
-                msg:  CString::new(String::from("Some error occured")).unwrap(),
-            }
-        };
-        return err;
-    }
-}
-
-impl From<graphdb::Error> for Error {
-    fn from(e: graphdb::Error) -> Error {
-        let err = if let Ok(error_msg) = CString::new(String::from(format!("{:?}", e))) {
-            Error {
-                msg: error_msg,
-            }
-        } else {
-            // meta-error
-            Error {
-                msg:  CString::new(String::from("Some error occured")).unwrap(),
-            }
-        };
-        return err;
-    }
-}
 
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Error {
@@ -91,7 +58,7 @@ impl From<log::SetLoggerError> for Error {
     }
 }
 
-pub fn new(err : api::corpusstorage::Error) -> * mut Error {
+pub fn new(err : errors::Error) -> * mut Error {
     Box::into_raw(Box::new(Error::from(err)))
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,51 @@
+// `error_chain!` can recurse deeply
+#![recursion_limit = "1024"]
+
+use Component;
+use query::conjunction;
+use graphstorage::registry;
+use StringID;
+
+error_chain! {
+
+    foreign_links {
+        CSV(::csv::Error);
+        IO(::std::io::Error);
+        ParseIntError(::std::num::ParseIntError);
+        RegistryError(registry::RegistryError);
+        Bincode(::bincode::Error);
+        Fmt(::std::fmt::Error);
+    }
+
+    errors {
+        LoadingComponentFailed(c: Component) {
+            description("Could not load component from disk"),
+            display("Could not load component {} from disk", c),
+        }
+
+        LoadingDBFailed(db : String) {
+            description("Could not load GraphDB from disk"),
+            display("Could not load GraphDB {} from disk", &db),
+        }
+
+        ImpossibleSearch(reasons : Vec<conjunction::Error>) {
+            description("Impossible search expression detected"),
+            display("Impossible search expression detected, reasons: {:?}", reasons),
+        }
+
+        NoSuchStringID(id : StringID) {
+            description("String ID does not exist"),
+            display("String with ID {} does not exist", id),
+        }
+
+        NoSuchString(val : String) {
+            description("String does not exist"),
+            display("String '{}' does not exist", &val),
+        }
+
+        NoSuchCorpus(name : String) {
+            description("No such corpus found"),
+            display("Corpus {} not found", &name)
+        }
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,9 +1,5 @@
-// `error_chain!` can recurse deeply
-#![recursion_limit = "1024"]
-
 use Component;
 use query::conjunction;
-use graphstorage::registry;
 use StringID;
 
 error_chain! {
@@ -12,9 +8,9 @@ error_chain! {
         CSV(::csv::Error);
         IO(::std::io::Error);
         ParseIntError(::std::num::ParseIntError);
-        RegistryError(registry::RegistryError);
         Bincode(::bincode::Error);
         Fmt(::std::fmt::Error);
+        Strum(::strum::ParseError);
     }
 
     errors {

--- a/src/graphdb.rs
+++ b/src/graphdb.rs
@@ -1,31 +1,29 @@
-use graphstorage::adjacencylist::AdjacencyListStorage;
-use stringstorage::StringStorage;
 use annostorage::AnnoStorage;
-use graphstorage::{GraphStorage, WriteableGraphStorage};
 use api::update::{GraphUpdate, UpdateEvent};
-use {Annotation, Component, ComponentType, Edge, NodeID, StringID};
-use AnnoKey;
-use graphstorage::registry;
-use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
-use std::io::prelude::*;
-use std::str::FromStr;
-use std::sync::{Arc,Mutex};
-use std;
-use strum::IntoEnumIterator;
-use std::string::ToString;
 use bincode;
-use serde;
-use malloc_size_of::{MallocSizeOf,MallocSizeOfOps};
-use tempdir::TempDir;
 use errors::*;
-
+use graphstorage::adjacencylist::AdjacencyListStorage;
+use graphstorage::registry;
+use graphstorage::{GraphStorage, WriteableGraphStorage};
+use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
+use serde;
+use std;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::sync::{Arc, Mutex};
+use stringstorage::StringStorage;
+use strum::IntoEnumIterator;
+use tempdir::TempDir;
+use AnnoKey;
+use {Annotation, Component, ComponentType, Edge, NodeID, StringID};
 
 pub const ANNIS_NS: &str = "annis";
 pub const NODE_NAME: &str = "node_name";
 pub const TOK: &str = "tok";
 pub const NODE_TYPE: &str = "node_type";
-
 
 pub struct GraphDB {
     pub strings: Arc<StringStorage>,
@@ -39,16 +37,14 @@ pub struct GraphDB {
     id_tok: StringID,
     id_node_type: StringID,
 
-    current_change_id : u64,
+    current_change_id: u64,
 
-    background_persistance : Arc<Mutex<()>>,
+    background_persistance: Arc<Mutex<()>>,
 }
 
 impl MallocSizeOf for GraphDB {
-
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        let mut size =
-            self.strings.size_of(ops) + self.node_annos.size_of(ops);
+        let mut size = self.strings.size_of(ops) + self.node_annos.size_of(ops);
 
         for (c, gs) in self.components.iter() {
             // TODO: overhead by map is not measured
@@ -58,7 +54,6 @@ impl MallocSizeOf for GraphDB {
         return size;
     }
 }
-
 
 fn load_component_from_disk(component_path: Option<PathBuf>) -> Result<Arc<GraphStorage>> {
     let cpath = try!(component_path.ok_or("Can't load component with empty path"));
@@ -82,7 +77,11 @@ fn component_to_relative_path(c: &Component) -> PathBuf {
     let mut p = PathBuf::new();
     p.push("gs");
     p.push(c.ctype.to_string());
-    p.push(if c.layer.is_empty() {"default_layer"} else {&c.layer});
+    p.push(if c.layer.is_empty() {
+        "default_layer"
+    } else {
+        &c.layer
+    });
     p.push(&c.name);
     return p;
 }
@@ -94,7 +93,12 @@ where
     let mut full_path = PathBuf::from(location);
     full_path.push(path);
 
-    let f = std::fs::File::open(full_path)?;
+    let f = std::fs::File::open(full_path.clone()).chain_err(|| {
+        format!(
+            "Could not load serialized file {}",
+            full_path.to_string_lossy()
+        )
+    })?;
     let mut reader = std::io::BufReader::new(f);
     let result: T = bincode::deserialize_from(&mut reader)?;
     return Ok(result);
@@ -129,16 +133,14 @@ impl GraphDB {
             components: BTreeMap::new(),
 
             location: None,
-            
+
             current_change_id: 0,
 
             background_persistance: Arc::new(Mutex::new(())),
         }
     }
 
-
-    fn set_location(&mut self, location : &Path) -> Result<()> {
-        
+    fn set_location(&mut self, location: &Path) -> Result<()> {
         self.location = Some(PathBuf::from(location));
 
         Ok(())
@@ -157,7 +159,7 @@ impl GraphDB {
 
         self.set_location(location.as_path())?;
         let backup = location.join("backup");
-        
+
         let mut backup_was_loaded = false;
         let dir2load = if backup.exists() && backup.is_dir() {
             backup_was_loaded = true;
@@ -166,9 +168,9 @@ impl GraphDB {
             location.join("current")
         };
 
-        let strings_tmp : StringStorage = load_bincode(&dir2load, "strings.bin")?;
+        let strings_tmp: StringStorage = load_bincode(&dir2load, "strings.bin")?;
         self.strings = Arc::new(strings_tmp);
-        let node_annos_tmp : AnnoStorage<NodeID> = load_bincode(&dir2load, "nodes.bin")?; 
+        let node_annos_tmp: AnnoStorage<NodeID> = load_bincode(&dir2load, "nodes.bin")?;
         self.node_annos = Arc::from(node_annos_tmp);
 
         let log_path = dir2load.join("update_log.bin");
@@ -189,7 +191,7 @@ impl GraphDB {
             // apply any outstanding log file updates
             let f_log = std::fs::File::open(log_path)?;
             let mut buf_reader = std::io::BufReader::new(f_log);
-            let update : GraphUpdate = bincode::deserialize_from(&mut buf_reader)?;
+            let update: GraphUpdate = bincode::deserialize_from(&mut buf_reader)?;
             if update.get_last_consistent_change_id() > self.current_change_id {
                 self.apply_update_in_memory(&update)?;
             }
@@ -201,11 +203,11 @@ impl GraphDB {
             // save the current corpus under the actual location
             self.save_to(&location.join("current"))?;
             // rename backup folder (renaming is atomic and deleting could leave an incomplete backup folder on disk)
-            let tmp_dir = TempDir::new_in(location,"temporary-graphannis-backup")?;
+            let tmp_dir = TempDir::new_in(location, "temporary-graphannis-backup")?;
             std::fs::rename(&backup, tmp_dir.path())?;
             // remove it after renaming it
             tmp_dir.close()?;
-        } 
+        }
 
         Ok(())
     }
@@ -216,7 +218,7 @@ impl GraphDB {
         // for all component types
         for c in ComponentType::iter() {
             let cpath = PathBuf::from(location).join("gs").join(c.to_string());
-          
+
             if cpath.is_dir() {
                 // get all the namespaces/layers
                 for layer in cpath.read_dir()? {
@@ -232,7 +234,7 @@ impl GraphDB {
                             let input_file = PathBuf::from(location)
                                 .join(component_to_relative_path(&empty_name_component))
                                 .join("component.bin");
-                        
+
                             if input_file.is_file() {
                                 self.components.insert(empty_name_component.clone(), None);
                                 debug!("Registered component {}", empty_name_component);
@@ -253,7 +255,7 @@ impl GraphDB {
                             let cfg_file = PathBuf::from(location)
                                 .join(component_to_relative_path(&named_component))
                                 .join("impl.cfg");
-                                
+
                             if data_file.is_file() && cfg_file.is_file() {
                                 self.components.insert(named_component.clone(), None);
                                 debug!("Registered component {}", named_component);
@@ -310,12 +312,11 @@ impl GraphDB {
 
     /// Save the current database at a new location and remember it
     pub fn persist_to(&mut self, location: &Path) -> Result<()> {
-        
         self.set_location(location)?;
         return self.internal_save(&location.join("current"));
     }
 
-    fn apply_update_in_memory(&mut self, u : &GraphUpdate) -> Result<()> {
+    fn apply_update_in_memory(&mut self, u: &GraphUpdate) -> Result<()> {
         for (id, change) in u.consistent_changes() {
             trace!("applying event {:?}", &change);
             match change {
@@ -326,11 +327,12 @@ impl GraphDB {
                     let existing_node_id = self.get_node_id_from_name(&node_name);
                     // only add node if it does not exist yet
                     if existing_node_id.is_none() {
-                        let new_node_id: NodeID = if let Some(id) = self.node_annos.get_largest_item() {
-                            id + 1
-                        } else {
-                            0
-                        };
+                        let new_node_id: NodeID =
+                            if let Some(id) = self.node_annos.get_largest_item() {
+                                id + 1
+                            } else {
+                                0
+                            };
                         let new_anno_name = Annotation {
                             key: self.get_node_name_key(),
                             val: Arc::make_mut(&mut self.strings).add(&node_name),
@@ -481,7 +483,7 @@ impl GraphDB {
                     anno_ns,
                     anno_name,
                 } => {
-                     if let (Some(source), Some(target)) = (
+                    if let (Some(source), Some(target)) = (
                         self.get_node_id_from_name(&source_node),
                         self.get_node_id_from_name(&target_node),
                     ) {
@@ -526,21 +528,19 @@ impl GraphDB {
         if let Some(location) = self.location.clone() {
             trace!("output location for persisting updates is {:?}", location);
             if result.is_ok() {
-
                 let current_path = PathBuf::from(location).join("current");
                 // make sure the output path exits
                 std::fs::create_dir_all(&current_path)?;
 
                 // if successfull write log
                 let log_path = current_path.join("update_log.bin");
-                
+
                 trace!("writing WAL update log to {:?}", &log_path);
                 let f_log = std::fs::File::create(log_path)?;
                 let mut buf_writer = std::io::BufWriter::new(f_log);
                 bincode::serialize_into(&mut buf_writer, &mut u)?;
 
                 trace!("finished writing WAL update log");
-
             } else {
                 trace!("error occured while applying updates: {:?}", &result);
                 // load corpus from disk again
@@ -554,11 +554,9 @@ impl GraphDB {
 
     /// A function to persist the changes of a write-ahead-log update on the disk. Should be run in a background thread.
     pub fn background_sync_wal_updates(&self) -> Result<()> {
-        
         // TODO: friendly abort any currently running thread
 
         if let Some(ref location) = self.location {
-    
             // Accuire lock, so that only one thread can write background data at the same time
             let _lock = self.background_persistance.lock().unwrap();
 
@@ -569,7 +567,10 @@ impl GraphDB {
             // A sub-folder is used to ensure that all directories are on the same file system and moving (instead of copying)
             // is possible.
             if !location.join("backup").exists() {
-                std::fs::rename(location.join("current"), location.join(location.join("backup")))?;
+                std::fs::rename(
+                    location.join("current"),
+                    location.join(location.join("backup")),
+                )?;
             }
 
             // Save the complete corpus without the write log to the target location
@@ -577,10 +578,9 @@ impl GraphDB {
 
             // remove the backup folder (since the new folder was completly written)
             std::fs::remove_dir_all(location.join("backup"))?;
-        } 
+        }
 
-        Ok(())   
-
+        Ok(())
     }
 
     fn component_path(&self, c: &Component) -> Option<PathBuf> {
@@ -620,7 +620,7 @@ impl GraphDB {
             let loaded_comp = if is_writable {
                 loaded_comp
             } else {
-                let mut gs_copy : AdjacencyListStorage = registry::create_writeable();
+                let mut gs_copy: AdjacencyListStorage = registry::create_writeable();
                 gs_copy.copy(&self, loaded_comp.as_edgecontainer());
                 Arc::from(gs_copy)
             };
@@ -633,7 +633,10 @@ impl GraphDB {
 
     pub fn calculate_component_statistics(&mut self, c: &Component) -> Result<()> {
         let mut result: Result<()> = Ok(());
-        let mut entry = self.components.remove(c).ok_or(format!("Component {} is missing", c.clone()))?;
+        let mut entry = self
+            .components
+            .remove(c)
+            .ok_or(format!("Component {} is missing", c.clone()))?;
         if let Some(ref mut gs) = entry {
             if let Some(gs_mut) = Arc::get_mut(gs) {
                 gs_mut.calculate_statistics(&self.strings);
@@ -646,10 +649,7 @@ impl GraphDB {
         return result;
     }
 
-    pub fn get_or_create_writable(
-        &mut self,
-        c: Component,
-    ) -> Result<&mut WriteableGraphStorage> {
+    pub fn get_or_create_writable(&mut self, c: Component) -> Result<&mut WriteableGraphStorage> {
         if self.components.contains_key(&c) {
             // make sure the component is actually writable and loaded
             self.insert_or_copy_writeable(&c)?;
@@ -660,12 +660,14 @@ impl GraphDB {
         }
 
         // get and return the reference to the entry
-        let entry: &mut Arc<GraphStorage> = self.components
+        let entry: &mut Arc<GraphStorage> = self
+            .components
             .get_mut(&c)
             .ok_or("Could not get mutable reference")?
             .as_mut()
             .ok_or("Could not get mutable reference to optional value")?;
-        let gs_mut_ref: &mut GraphStorage = Arc::get_mut(entry).ok_or("Could not get mutable reference")?;
+        let gs_mut_ref: &mut GraphStorage =
+            Arc::get_mut(entry).ok_or("Could not get mutable reference")?;
         return Ok(gs_mut_ref.as_writeable().ok_or("Invalid type")?);
     }
 
@@ -864,11 +866,12 @@ mod tests {
         };
         let anno_val = Arc::make_mut(&mut db.strings).add("testValue");
 
-        let gs: &mut WriteableGraphStorage = db.get_or_create_writable(Component {
-            ctype: ComponentType::Pointing,
-            layer: String::from("test"),
-            name: String::from("dep"),
-        }).unwrap();
+        let gs: &mut WriteableGraphStorage =
+            db.get_or_create_writable(Component {
+                ctype: ComponentType::Pointing,
+                layer: String::from("test"),
+                name: String::from("dep"),
+            }).unwrap();
 
         gs.add_edge(Edge {
             source: 0,

--- a/src/graphstorage/registry.rs
+++ b/src/graphstorage/registry.rs
@@ -1,4 +1,3 @@
-use graphstorage::registry::RegistryError::Serialization;
 use graphstorage::{GraphStorage, GraphStatistic};
 use super::adjacencylist::AdjacencyListStorage;
 use super::prepost::PrePostOrderStorage;
@@ -8,31 +7,8 @@ use std::sync::Arc;
 use bincode;
 use std::any::Any;
 use std::str::FromStr;
-use strum;
-use std::fmt;
+use errors::*;
 
-#[derive(Debug)]
-pub enum RegistryError {
-    ImplementationNameNotFound,
-    TypeNotFound,
-    Serialization(Box<bincode::ErrorKind>),
-}
-
-
-impl fmt::Display for RegistryError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            ImplementationNameNotFound => write!(f, "Implementation name not found"),
-            TypeNotFound => write!(f, "Type not found"),
-            Serialization(bincode_error) => write!(f, "Serialization error: {}", bincode_error),
-        }
-        
-    }
-}
-
-impl std::error::Error for RegistryError {
-
-}
 
 #[derive(ToString, Debug, Clone, EnumString,PartialEq)]
 pub enum ImplTypes {
@@ -46,19 +22,6 @@ pub enum ImplTypes {
     LinearO8V1,
 }
 
-impl From<Box<bincode::ErrorKind>> for RegistryError {
-    fn from(e: Box<bincode::ErrorKind>) -> RegistryError {
-        RegistryError::Serialization(e)
-    }
-}
-
-impl From<strum::ParseError> for RegistryError {
-    fn from(_: strum::ParseError) -> RegistryError {
-        RegistryError::ImplementationNameNotFound
-    }
-}
-
-type Result<T> = std::result::Result<T, RegistryError>;
 
 pub fn create_writeable() -> AdjacencyListStorage {
     // TODO: make this configurable when there are more writeable graph storage implementations
@@ -197,7 +160,7 @@ pub fn get_type(data : Arc<GraphStorage>) -> Result<ImplTypes> {
     } else if let Some(_) = data.downcast_ref::<LinearGraphStorage<u8>>() {
         return Ok(ImplTypes::LinearO8V1);
     }
-    return Err(RegistryError::TypeNotFound);
+    return Err("Type not found".into());
 }
 
 pub fn serialize(data : Arc<GraphStorage>, writer : &mut std::io::Write) -> Result<String> {
@@ -227,7 +190,7 @@ pub fn serialize(data : Arc<GraphStorage>, writer : &mut std::io::Write) -> Resu
         bincode::serialize_into(writer, gs)?;
         return Ok(ImplTypes::LinearO8V1.to_string());
     }
-    return Err(RegistryError::TypeNotFound);
+    return Err("Type not found".into());
 }
 
 

--- a/src/graphstorage/registry.rs
+++ b/src/graphstorage/registry.rs
@@ -1,3 +1,4 @@
+use graphstorage::registry::RegistryError::Serialization;
 use graphstorage::{GraphStorage, GraphStatistic};
 use super::adjacencylist::AdjacencyListStorage;
 use super::prepost::PrePostOrderStorage;
@@ -8,14 +9,29 @@ use bincode;
 use std::any::Any;
 use std::str::FromStr;
 use strum;
+use std::fmt;
 
 #[derive(Debug)]
 pub enum RegistryError {
-    Empty,
     ImplementationNameNotFound,
     TypeNotFound,
     Serialization(Box<bincode::ErrorKind>),
-    Other,
+}
+
+
+impl fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ImplementationNameNotFound => write!(f, "Implementation name not found"),
+            TypeNotFound => write!(f, "Type not found"),
+            Serialization(bincode_error) => write!(f, "Serialization error: {}", bincode_error),
+        }
+        
+    }
+}
+
+impl std::error::Error for RegistryError {
+
 }
 
 #[derive(ToString, Debug, Clone, EnumString,PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,9 +38,7 @@ extern crate rayon;
 extern crate sys_info;
 extern crate fs2;
 
-mod errors {
-    error_chain! {}
-}
+pub mod errors;
 
 #[macro_use]
 pub mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// `error_chain!` can recurse deeply
+#![recursion_limit = "1024"]
+
 extern crate graphannis_malloc_size_of as malloc_size_of;
 #[macro_use]
 extern crate graphannis_malloc_size_of_derive as malloc_size_of_derive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@ extern crate graphannis_malloc_size_of_derive as malloc_size_of_derive;
 #[macro_use]
 extern crate log;
 
+#[macro_use]
+extern crate error_chain;
+
 extern crate regex;
 extern crate regex_syntax;
 extern crate rand;
@@ -35,6 +38,9 @@ extern crate rayon;
 extern crate sys_info;
 extern crate fs2;
 
+mod errors {
+    error_chain! {}
+}
 
 #[macro_use]
 pub mod util;

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -7,11 +7,8 @@ use exec::{Desc, ExecutionNode};
 use std;
 use std::fmt::Formatter;
 use std::collections::HashSet;
+use errors::*;
 
-#[derive(Debug)]
-pub enum Error {
-    ImpossibleSearch(Vec<conjunction::Error>),
-}
 
 pub struct ExecutionPlan<'a> {
     plans: Vec<Box<ExecutionNode<Item = Vec<Match>> + 'a>>,
@@ -26,7 +23,7 @@ impl<'a> ExecutionPlan<'a> {
         query: &'a Disjunction<'a>,
         db: &'a GraphDB,
         config : Config,
-    ) -> Result<ExecutionPlan<'a>, Error> {
+    ) -> Result<ExecutionPlan<'a>> {
         let mut plans: Vec<Box<ExecutionNode<Item = Vec<Match>> + 'a>> = Vec::new();
         let mut descriptions: Vec<Option<Desc>> = Vec::new();
         let mut errors: Vec<conjunction::Error> = Vec::new();
@@ -41,7 +38,7 @@ impl<'a> ExecutionPlan<'a> {
         }
 
         if plans.is_empty() {
-            return Err(Error::ImpossibleSearch(errors));
+            return Err(ErrorKind::ImpossibleSearch(errors).into());
         } else {
             return Ok(ExecutionPlan {
                 current_plan: 0,


### PR DESCRIPTION
This should make it easier to give more detailed error messages and backtraces, which in turn helps to debug errors that are only logged in CI, but are difficult to reproduce in developer machines.