### PR TITLE
Wait for all background writers before dropping the CorpusStorage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ kernel32-sys = { version = "0.2.2" }
 
 [dev-dependencies]
 bencher = "0.1"
+simplelog = "0.5"
 
 [features]
 cli = ["rustyline", "simplelog", "clap", "bencher", "prettytable-rs"]

--- a/src/api/corpusstorage.rs
+++ b/src/api/corpusstorage.rs
@@ -1340,6 +1340,8 @@ impl CorpusStorage {
 #[cfg(test)]
 mod tests {
     extern crate tempdir;
+    extern crate simplelog;
+    extern crate log;
 
     use api::corpusstorage::CorpusStorage;
     use api::update::{GraphUpdate, UpdateEvent};
@@ -1363,6 +1365,9 @@ mod tests {
 
     #[test]
     fn load_cs_twice() {
+        // Init logger to get a trace of the actions that failed
+        simplelog::SimpleLogger::init(log::LevelFilter::Trace, simplelog::Config::default()).unwrap();
+
         if let Ok(tmp) = tempdir::TempDir::new("annis_test") {
             {
                 let cs = CorpusStorage::new_auto_cache_size(tmp.path(), false).unwrap();


### PR DESCRIPTION
This should help to prevent errors where two CorpusStorage instances are created on the same directory after each other and where the first one has some updates that need to be applied in the background thread.