### PR TITLE
Simplify the code for the graph storage registry

### DIFF
--- a/src/graphdb.rs
+++ b/src/graphdb.rs
@@ -692,14 +692,13 @@ impl GraphDB {
 
     pub fn optimize_impl(&mut self, c: &Component) {
         if let Some(gs) = self.get_graphstorage(c) {
-            let existing_type = registry::get_type(gs.clone());
 
             if let Some(stats) = gs.get_statistics() {
-                let opt_type = registry::get_optimal_impl_heuristic(stats);
+                let opt_info = registry::get_optimal_impl_heuristic(stats);
 
                 // convert if necessary
-                if existing_type.is_err() || opt_type != existing_type.unwrap() {
-                    let mut new_gs = registry::create_from_type(opt_type.clone());
+                if opt_info.id != gs.serialization_id() {
+                    let mut new_gs = registry::create_from_info(&opt_info);
                     let converted = if let Some(new_gs_mut) = Arc::get_mut(&mut new_gs) {
                         new_gs_mut.copy(self, gs.as_edgecontainer());
                         true
@@ -711,7 +710,7 @@ impl GraphDB {
                         info!(
                             "Converted component {} to implementation {}",
                             c,
-                            opt_type.to_string()
+                            opt_info.id,
                         );
                         self.components.insert(c.clone(), Some(new_gs.clone()));
                     }

--- a/src/graphstorage/adjacencylist.rs
+++ b/src/graphstorage/adjacencylist.rs
@@ -7,6 +7,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::BTreeSet;
 
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
+use bincode;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct AdjacencyListStorage {
@@ -90,6 +91,16 @@ impl EdgeContainer for AdjacencyListStorage {
 }
 
 impl GraphStorage for AdjacencyListStorage {
+
+    fn serialization_id(&self) -> String {
+        "AdjacencyListV1".to_owned()
+    }
+
+    fn serialize(&self, writer: &mut std::io::Write) -> Result<()> {
+        bincode::serialize_into(writer, self)?;
+        Ok(())
+    }
+
     fn find_connected<'a>(
         &'a self,
         node: &NodeID,

--- a/src/graphstorage/adjacencylist.rs
+++ b/src/graphstorage/adjacencylist.rs
@@ -27,6 +27,12 @@ impl MallocSizeOf for AdjacencyListStorage {
     }
 }
 
+impl Default for AdjacencyListStorage {
+    fn default() -> Self {
+        AdjacencyListStorage::new()
+    }
+}
+
 impl AdjacencyListStorage {
     pub fn new() -> AdjacencyListStorage {
         AdjacencyListStorage {
@@ -96,7 +102,7 @@ impl GraphStorage for AdjacencyListStorage {
         "AdjacencyListV1".to_owned()
     }
 
-    fn serialize(&self, writer: &mut std::io::Write) -> Result<()> {
+    fn serialize_gs(&self, writer: &mut std::io::Write) -> Result<()> {
         bincode::serialize_into(writer, self)?;
         Ok(())
     }

--- a/src/graphstorage/linear.rs
+++ b/src/graphstorage/linear.rs
@@ -4,6 +4,7 @@ use rustc_hash::FxHashSet;
 use std::any::Any;
 use std::clone::Clone;
 use std;
+use serde::{Serialize, Deserialize};
 use bincode;
 
 use {AnnoKey, Annotation, Edge, Match, NodeID, NumValue};
@@ -109,7 +110,7 @@ where PosT : NumValue {
 
 impl<PosT: 'static> GraphStorage for LinearGraphStorage<PosT>
 where
-    PosT: NumValue,
+    for <'de> PosT: NumValue + Deserialize<'de> + Serialize,
 {
     fn serialization_id(&self) -> String {
         format!("LinearO{}V1", std::mem::size_of::<PosT>()*8)

--- a/src/graphstorage/linear.rs
+++ b/src/graphstorage/linear.rs
@@ -4,12 +4,14 @@ use rustc_hash::FxHashSet;
 use std::any::Any;
 use std::clone::Clone;
 use std;
+use bincode;
 
 use {AnnoKey, Annotation, Edge, Match, NodeID, NumValue};
 use super::{GraphStatistic, GraphStorage};
 use annostorage::AnnoStorage;
 use graphdb::GraphDB;
 use dfs::{CycleSafeDFS, DFSStep};
+use errors::*;
 
 #[derive(Serialize, Deserialize, Clone, MallocSizeOf)]
 struct RelativePosition<PosT> {
@@ -109,6 +111,15 @@ impl<PosT: 'static> GraphStorage for LinearGraphStorage<PosT>
 where
     PosT: NumValue,
 {
+    fn serialization_id(&self) -> String {
+        format!("LinearO{}V1", std::mem::size_of::<PosT>()*8)
+    }
+
+    fn serialize(&self, writer: &mut std::io::Write) -> Result<()> {
+        bincode::serialize_into(writer, self)?;
+        Ok(())
+    }
+
     fn find_connected<'a>(
         &'a self,
         source: &NodeID,

--- a/src/graphstorage/linear.rs
+++ b/src/graphstorage/linear.rs
@@ -49,6 +49,15 @@ where
     }
 }
 
+impl<PosT> Default for LinearGraphStorage<PosT> 
+where
+    PosT: NumValue,
+{
+    fn default() -> Self {
+        LinearGraphStorage::new()
+    }
+}
+
 
 impl<PosT: 'static> EdgeContainer for  LinearGraphStorage<PosT> 
 where PosT : NumValue {
@@ -116,7 +125,7 @@ where
         format!("LinearO{}V1", std::mem::size_of::<PosT>()*8)
     }
 
-    fn serialize(&self, writer: &mut std::io::Write) -> Result<()> {
+    fn serialize_gs(&self, writer: &mut std::io::Write) -> Result<()> {
         bincode::serialize_into(writer, self)?;
         Ok(())
     }

--- a/src/graphstorage/mod.rs
+++ b/src/graphstorage/mod.rs
@@ -4,6 +4,7 @@ use {AnnoKey, Annotation, Edge, NodeID};
 use annostorage::AnnoStorage;
 use graphdb::GraphDB;
 use malloc_size_of::MallocSizeOf;
+use errors::*;
 
 /// Some general statistical numbers specific to a graph component
 #[derive(Serialize, Deserialize, Clone, MallocSizeOf)]
@@ -78,6 +79,9 @@ pub trait GraphStorage : EdgeContainer {
     fn inverse_has_same_cost(&self) -> bool {false}    
 
     fn calculate_statistics(&mut self) {}
+
+    fn serialization_id(&self) -> String;
+    fn serialize(&self, writer : &mut std::io::Write) -> Result<()>;
 
 }
 

--- a/src/graphstorage/mod.rs
+++ b/src/graphstorage/mod.rs
@@ -1,6 +1,5 @@
 use std;
 use std::any::Any;
-use std::sync::Arc;
 use serde::Deserialize;
 use {AnnoKey, Annotation, Edge, NodeID};
 use annostorage::AnnoStorage;
@@ -85,12 +84,12 @@ pub trait GraphStorage : EdgeContainer {
 
     fn serialization_id(&self) -> String;
 
-    fn serialize(&self, writer: &mut std::io::Write) -> Result<()>;
+    fn serialize_gs(&self, writer: &mut std::io::Write) -> Result<()>;
 
-    fn deserialize(input : &mut std::io::Read) -> Result<Arc<Self>> 
+    fn deserialize_gs(input : &mut std::io::Read) -> Result<Self> 
     where for<'de> Self: std::marker::Sized +  Deserialize<'de> {
         let result = bincode::deserialize_from(input)?;
-        Ok(Arc::new(result))
+        Ok(result)
     }
 }
 

--- a/src/graphstorage/mod.rs
+++ b/src/graphstorage/mod.rs
@@ -1,9 +1,12 @@
 use std;
 use std::any::Any;
+use std::sync::Arc;
+use serde::Deserialize;
 use {AnnoKey, Annotation, Edge, NodeID};
 use annostorage::AnnoStorage;
 use graphdb::GraphDB;
 use malloc_size_of::MallocSizeOf;
+use bincode;
 use errors::*;
 
 /// Some general statistical numbers specific to a graph component
@@ -81,8 +84,14 @@ pub trait GraphStorage : EdgeContainer {
     fn calculate_statistics(&mut self) {}
 
     fn serialization_id(&self) -> String;
-    fn serialize(&self, writer : &mut std::io::Write) -> Result<()>;
 
+    fn serialize(&self, writer: &mut std::io::Write) -> Result<()>;
+
+    fn deserialize(input : &mut std::io::Read) -> Result<Arc<Self>> 
+    where for<'de> Self: std::marker::Sized +  Deserialize<'de> {
+        let result = bincode::deserialize_from(input)?;
+        Ok(Arc::new(result))
+    }
 }
 
 pub trait WriteableGraphStorage :  GraphStorage {

--- a/src/graphstorage/prepost.rs
+++ b/src/graphstorage/prepost.rs
@@ -48,6 +48,16 @@ struct NodeStackEntry<OrderT, LevelT> {
     pub order: PrePost<OrderT, LevelT>,
 }
 
+impl<OrderT, LevelT> Default for PrePostOrderStorage<OrderT, LevelT> 
+where
+    OrderT: NumValue,
+    LevelT: NumValue,
+{
+    fn default() -> Self {
+        PrePostOrderStorage::new()
+    }
+}
+
 impl<OrderT, LevelT> PrePostOrderStorage<OrderT, LevelT>
 where
     OrderT: NumValue,
@@ -151,7 +161,7 @@ where
         format!("PrePostOrderO{}L{}V1", std::mem::size_of::<OrderT>()*8, std::mem::size_of::<LevelT>()*8)
     }
 
-    fn serialize(&self, writer: &mut std::io::Write) -> Result<()> {
+    fn serialize_gs(&self, writer: &mut std::io::Write) -> Result<()> {
         bincode::serialize_into(writer, self)?;
         Ok(())
     }

--- a/src/graphstorage/prepost.rs
+++ b/src/graphstorage/prepost.rs
@@ -3,12 +3,14 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::any::Any;
 use std::clone::Clone;
 use std;
+use bincode;
 
 use {AnnoKey, Annotation, Edge, Match, NodeID, NumValue};
 use super::{GraphStatistic, GraphStorage};
 use annostorage::AnnoStorage;
 use graphdb::GraphDB;
 use dfs::{CycleSafeDFS, DFSStep};
+use errors::*;
 
 #[derive(PartialOrd, PartialEq, Ord, Eq, Clone, Serialize, Deserialize, MallocSizeOf)]
 pub struct PrePost<OrderT, LevelT> {
@@ -144,6 +146,15 @@ where
     OrderT: NumValue,
     LevelT: NumValue,
 {
+    fn serialization_id(&self) -> String {
+        format!("PrePostOrderO{}L{}V1", std::mem::size_of::<OrderT>()*8, std::mem::size_of::<LevelT>()*8)
+    }
+
+    fn serialize(&self, writer: &mut std::io::Write) -> Result<()> {
+        bincode::serialize_into(writer, self)?;
+        Ok(())
+    }
+
     fn find_connected<'a>(
         &'a self,
         node: &NodeID,

--- a/src/graphstorage/prepost.rs
+++ b/src/graphstorage/prepost.rs
@@ -3,6 +3,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::any::Any;
 use std::clone::Clone;
 use std;
+use serde::{Serialize, Deserialize};
 use bincode;
 
 use {AnnoKey, Annotation, Edge, Match, NodeID, NumValue};
@@ -105,8 +106,8 @@ type NStack<OrderT, LevelT> = std::collections::LinkedList<NodeStackEntry<OrderT
 
 impl<OrderT: 'static, LevelT: 'static> EdgeContainer for PrePostOrderStorage<OrderT, LevelT>
 where
-    OrderT: NumValue,
-    LevelT: NumValue,
+    for<'de> OrderT: NumValue +  Deserialize<'de> + Serialize,
+    for<'de> LevelT: NumValue + Deserialize<'de> + Serialize,
 {
     fn get_outgoing_edges<'a>(&'a self, node: &NodeID) -> Box<Iterator<Item = NodeID> + 'a> {
         return self.find_connected(node, 1, 1);
@@ -143,8 +144,8 @@ where
 
 impl<OrderT: 'static, LevelT: 'static> GraphStorage for PrePostOrderStorage<OrderT, LevelT>
 where
-    OrderT: NumValue,
-    LevelT: NumValue,
+    for<'de> OrderT: NumValue +  Deserialize<'de> + Serialize,
+    for<'de> LevelT: NumValue + Deserialize<'de> + Serialize,
 {
     fn serialization_id(&self) -> String {
         format!("PrePostOrderO{}L{}V1", std::mem::size_of::<OrderT>()*8, std::mem::size_of::<LevelT>()*8)
@@ -154,6 +155,7 @@ where
         bincode::serialize_into(writer, self)?;
         Ok(())
     }
+
 
     fn find_connected<'a>(
         &'a self,

--- a/src/graphstorage/registry.rs
+++ b/src/graphstorage/registry.rs
@@ -204,45 +204,8 @@ pub fn get_type(data : Arc<GraphStorage>) -> Result<ImplTypes> {
 }
 
 pub fn serialize(data : Arc<GraphStorage>, writer : &mut std::io::Write) -> Result<String> {
-    let data :&Any = data.as_any();
-    if let Some(gs) = data.downcast_ref::<AdjacencyListStorage>() {
-        bincode::serialize_into(writer, gs)?;
-        return Ok(ImplTypes::AdjacencyListV1.to_string());
-    } else if let Some(gs) = data.downcast_ref::<PrePostOrderStorage<u64,u64>>() {
-        bincode::serialize_into(writer, gs)?;
-        return Ok(ImplTypes::PrePostOrderO64L64V1.to_string());
-    } else if let Some(gs) = data.downcast_ref::<PrePostOrderStorage<u64,u32>>() {
-        bincode::serialize_into(writer, gs)?;
-        return Ok(ImplTypes::PrePostOrderO64L32V1.to_string());
-    } else if let Some(gs) = data.downcast_ref::<PrePostOrderStorage<u64,u8>>() {
-        bincode::serialize_into(writer, gs)?;
-        return Ok(ImplTypes::PrePostOrderO64L8V1.to_string());
-    } else if let Some(gs) = data.downcast_ref::<PrePostOrderStorage<u32,u32>>() {
-        bincode::serialize_into(writer, gs)?;
-        return Ok(ImplTypes::PrePostOrderO32L32V1.to_string());
-    } else if let Some(gs) = data.downcast_ref::<PrePostOrderStorage<u32,u8>>() {
-        bincode::serialize_into(writer, gs)?;
-        return Ok(ImplTypes::PrePostOrderO32L8V1.to_string());
-    } else if let Some(gs) = data.downcast_ref::<PrePostOrderStorage<u16,u32>>() {
-        bincode::serialize_into(writer, gs)?;
-        return Ok(ImplTypes::PrePostOrderO16L32V1.to_string());
-    } else if let Some(gs) = data.downcast_ref::<PrePostOrderStorage<u16,u8>>() {
-        bincode::serialize_into(writer, gs)?;
-        return Ok(ImplTypes::PrePostOrderO16L8V1.to_string());
-    } else if let Some(gs) = data.downcast_ref::<LinearGraphStorage<u64>>() {
-        bincode::serialize_into(writer, gs)?;
-        return Ok(ImplTypes::LinearO64V1.to_string());
-    } else if let Some(gs) = data.downcast_ref::<LinearGraphStorage<u32>>() {
-        bincode::serialize_into(writer, gs)?;
-        return Ok(ImplTypes::LinearO32V1.to_string());
-    } else if let Some(gs) = data.downcast_ref::<LinearGraphStorage<u16>>() {
-        bincode::serialize_into(writer, gs)?;
-        return Ok(ImplTypes::LinearO16V1.to_string());
-    } else if let Some(gs) = data.downcast_ref::<LinearGraphStorage<u8>>() {
-        bincode::serialize_into(writer, gs)?;
-        return Ok(ImplTypes::LinearO8V1.to_string());
-    }
-    return Err("Type not found".into());
+    data.serialize(writer)?;
+    Ok(data.serialization_id())
 }
 
 

--- a/src/graphstorage/registry.rs
+++ b/src/graphstorage/registry.rs
@@ -1,14 +1,12 @@
-use graphstorage::{GraphStorage, GraphStatistic};
 use super::adjacencylist::AdjacencyListStorage;
-use super::prepost::PrePostOrderStorage;
 use super::linear::LinearGraphStorage;
-use std;
-use std::sync::Arc;
-use std::collections::HashMap;
+use super::prepost::PrePostOrderStorage;
 use errors::*;
+use graphstorage::{GraphStatistic, GraphStorage};
 use serde::Deserialize;
-
-
+use std;
+use std::collections::HashMap;
+use std::sync::Arc;
 
 pub struct GSInfo {
     pub id: String,
@@ -21,14 +19,14 @@ lazy_static! {
         let mut m = HashMap::new();
 
         insert_info::<AdjacencyListStorage>(&mut m);
-        
-        insert_info::<PrePostOrderStorage<u64,u64>>(&mut m);
-        insert_info::<PrePostOrderStorage<u64,u32>>(&mut m);
-        insert_info::<PrePostOrderStorage<u64,u8>>(&mut m);
-        insert_info::<PrePostOrderStorage<u32,u32>>(&mut m);
-        insert_info::<PrePostOrderStorage<u32,u8>>(&mut m);
-        insert_info::<PrePostOrderStorage<u16,u32>>(&mut m);
-        insert_info::<PrePostOrderStorage<u16,u8>>(&mut m);
+
+        insert_info::<PrePostOrderStorage<u64, u64>>(&mut m);
+        insert_info::<PrePostOrderStorage<u64, u32>>(&mut m);
+        insert_info::<PrePostOrderStorage<u64, u8>>(&mut m);
+        insert_info::<PrePostOrderStorage<u32, u32>>(&mut m);
+        insert_info::<PrePostOrderStorage<u32, u8>>(&mut m);
+        insert_info::<PrePostOrderStorage<u16, u32>>(&mut m);
+        insert_info::<PrePostOrderStorage<u16, u8>>(&mut m);
 
         insert_info::<LinearGraphStorage<u64>>(&mut m);
         insert_info::<LinearGraphStorage<u32>>(&mut m);
@@ -43,10 +41,7 @@ pub fn create_writeable() -> AdjacencyListStorage {
     AdjacencyListStorage::new()
 }
 
-
-
-pub fn get_optimal_impl_heuristic(stats : &GraphStatistic) -> GSInfo {
-
+pub fn get_optimal_impl_heuristic(stats: &GraphStatistic) -> GSInfo {
     if stats.max_depth <= 1 {
         // if we don't have any deep graph structures an adjencency list is always fasted (and has no overhead)
         return create_info::<AdjacencyListStorage>();
@@ -70,38 +65,38 @@ pub fn get_optimal_impl_heuristic(stats : &GraphStatistic) -> GSInfo {
     return create_info::<AdjacencyListStorage>();;
 }
 
-fn get_prepostorder_by_size(stats : &GraphStatistic) -> GSInfo {
+fn get_prepostorder_by_size(stats: &GraphStatistic) -> GSInfo {
     if stats.rooted_tree {
         // There are exactly two order values per node and there can be only one order value per node
         // in a tree.
         if stats.nodes < (u16::max_value() / 2) as usize {
             if stats.max_depth < u8::max_value() as usize {
-                return create_info::<PrePostOrderStorage<u16,u8>>();
+                return create_info::<PrePostOrderStorage<u16, u8>>();
             } else if stats.max_depth < u32::max_value() as usize {
-                return create_info::<PrePostOrderStorage<u16,u32>>();
+                return create_info::<PrePostOrderStorage<u16, u32>>();
             }
         } else if stats.nodes < (u32::max_value() / 2) as usize {
             if stats.max_depth < u8::max_value() as usize {
-                return create_info::<PrePostOrderStorage<u32,u8>>();
+                return create_info::<PrePostOrderStorage<u32, u8>>();
             } else if stats.max_depth < u32::max_value() as usize {
-                return create_info::<PrePostOrderStorage<u32,u32>>();
+                return create_info::<PrePostOrderStorage<u32, u32>>();
             }
         } else {
             if stats.max_depth < u8::max_value() as usize {
-                return create_info::<PrePostOrderStorage<u64,u8>>();
+                return create_info::<PrePostOrderStorage<u64, u8>>();
             } else if stats.max_depth < u32::max_value() as usize {
-                return create_info::<PrePostOrderStorage<u64,u32>>();
+                return create_info::<PrePostOrderStorage<u64, u32>>();
             }
         }
     } else {
         if stats.max_depth < u8::max_value() as usize {
-            return create_info::<PrePostOrderStorage<u64,u8>>();
+            return create_info::<PrePostOrderStorage<u64, u8>>();
         }
     }
-    return create_info::<PrePostOrderStorage<u64,u64>>();;
+    return create_info::<PrePostOrderStorage<u64, u64>>();;
 }
 
-fn get_linear_by_size(stats : &GraphStatistic) -> GSInfo {
+fn get_linear_by_size(stats: &GraphStatistic) -> GSInfo {
     if stats.max_depth < u8::max_value() as usize {
         return create_info::<LinearGraphStorage<u8>>();
     } else if stats.max_depth < u16::max_value() as usize {
@@ -113,15 +108,18 @@ fn get_linear_by_size(stats : &GraphStatistic) -> GSInfo {
     }
 }
 
-
-fn insert_info<GS: 'static>(registry : &mut HashMap<String, GSInfo>) 
-where for<'de> GS: GraphStorage + Default +  Deserialize<'de> {
+fn insert_info<GS: 'static>(registry: &mut HashMap<String, GSInfo>)
+where
+    for<'de> GS: GraphStorage + Default + Deserialize<'de>,
+{
     let info = create_info::<GS>();
     registry.insert(info.id.clone(), info);
 }
 
-fn create_info<GS: 'static>() -> GSInfo 
-where for<'de> GS: GraphStorage + Default +  Deserialize<'de> {
+fn create_info<GS: 'static>() -> GSInfo
+where
+    for<'de> GS: GraphStorage + Default + Deserialize<'de>,
+{
     // create an instance to get the name
     let instance = GS::default();
 
@@ -132,22 +130,19 @@ where for<'de> GS: GraphStorage + Default +  Deserialize<'de> {
     }
 }
 
-
 pub fn create_from_info(info: &GSInfo) -> Arc<GraphStorage> {
     (info.constructor)()
 }
 
-
-pub fn deserialize(impl_name : &str, input : &mut std::io::Read) -> Result<Arc<GraphStorage>> {
-
-    let info =  REGISTRY.get(impl_name).ok_or(format!("Could not find implementation for graph storage with name '{}'", impl_name))?;
+pub fn deserialize(impl_name: &str, input: &mut std::io::Read) -> Result<Arc<GraphStorage>> {
+    let info = REGISTRY.get(impl_name).ok_or(format!(
+        "Could not find implementation for graph storage with name '{}'",
+        impl_name
+    ))?;
     return (info.deserialize_func)(input);
 }
 
-
-pub fn serialize(data : Arc<GraphStorage>, writer : &mut std::io::Write) -> Result<String> {
+pub fn serialize(data: Arc<GraphStorage>, writer: &mut std::io::Write) -> Result<String> {
     data.serialize_gs(writer)?;
     Ok(data.serialization_id())
 }
-
-

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,4 @@
 use num::{Bounded, FromPrimitive, Num, ToPrimitive};
-use serde::{Serialize};
 use std;
 use std::fmt;
 use std::ops::AddAssign;
@@ -136,7 +135,6 @@ pub trait NumValue:
     + Bounded
     + FromPrimitive
     + ToPrimitive
-    + Serialize
     + MallocSizeOf
 {
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,14 +1,27 @@
-use num::{Num,FromPrimitive, Bounded, ToPrimitive};
-use std::string::String;
+use num::{Bounded, FromPrimitive, Num, ToPrimitive};
+use serde::{Serialize};
+use std;
 use std::fmt;
 use std::ops::AddAssign;
-use std;
+use std::string::String;
 
 use malloc_size_of::MallocSizeOf;
 
 pub type NodeID = u64;
 
-#[derive(Serialize, Deserialize, Default, Eq, PartialEq, PartialOrd, Ord, Clone, Debug, MallocSizeOf, Hash)]
+#[derive(
+    Serialize,
+    Deserialize,
+    Default,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Debug,
+    MallocSizeOf,
+    Hash,
+)]
 #[repr(C)]
 pub struct AnnoKey {
     pub name: String,
@@ -38,7 +51,19 @@ pub struct CountExtra {
     pub document_count: u64,
 }
 
-#[derive(Serialize, Deserialize, Eq, PartialEq, PartialOrd, Ord, Clone, Debug, Hash, MallocSizeOf, Default)]
+#[derive(
+    Serialize,
+    Deserialize,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Debug,
+    Hash,
+    MallocSizeOf,
+    Default,
+)]
 #[repr(C)]
 pub struct Edge {
     pub source: NodeID,
@@ -47,11 +72,27 @@ pub struct Edge {
 
 impl Edge {
     pub fn inverse(&self) -> Edge {
-        Edge {source: self.target, target: self.source}
+        Edge {
+            source: self.target,
+            target: self.source,
+        }
     }
 }
 
-#[derive(Serialize, Deserialize, Eq, PartialEq, PartialOrd, Ord, Hash, Clone, Debug, EnumIter, EnumString, MallocSizeOf)]
+#[derive(
+    Serialize,
+    Deserialize,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Clone,
+    Debug,
+    EnumIter,
+    EnumString,
+    MallocSizeOf,
+)]
 #[repr(C)]
 pub enum ComponentType {
     Coverage,
@@ -70,11 +111,13 @@ impl fmt::Display for ComponentType {
     }
 }
 
-#[derive(Serialize, Deserialize, Eq, PartialEq, PartialOrd, Ord, Hash, Clone, Debug, MallocSizeOf)]
+#[derive(
+    Serialize, Deserialize, Eq, PartialEq, PartialOrd, Ord, Hash, Clone, Debug, MallocSizeOf,
+)]
 pub struct Component {
-    pub ctype : ComponentType,
-    pub name : String,
-    pub layer : String,
+    pub ctype: ComponentType,
+    pub name: String,
+    pub layer: String,
 }
 
 impl std::fmt::Display for Component {
@@ -83,8 +126,19 @@ impl std::fmt::Display for Component {
     }
 }
 
-pub trait NumValue : Send + Sync + Ord + Num + AddAssign + Clone + Bounded + FromPrimitive + ToPrimitive + MallocSizeOf {
-
+pub trait NumValue:
+    Send
+    + Sync
+    + Ord
+    + Num
+    + AddAssign
+    + Clone
+    + Bounded
+    + FromPrimitive
+    + ToPrimitive
+    + Serialize
+    + MallocSizeOf
+{
 }
 
 impl NumValue for u64 {}
@@ -100,15 +154,15 @@ pub type FrequencyTable<T> = Vec<(Vec<T>, usize)>;
 
 pub struct NodeDesc {
     pub component_nr: usize,
-    pub aql_fragment : String,
+    pub aql_fragment: String,
     pub variable: String,
-    pub anno_name : Option<String>,
+    pub anno_name: Option<String>,
 }
 
-#[derive(Clone,Debug,PartialEq,Eq,Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct LineColumn {
-    pub line : usize,
-    pub column : usize,
+    pub line: usize,
+    pub column: usize,
 }
 
 impl std::fmt::Display for LineColumn {
@@ -117,10 +171,10 @@ impl std::fmt::Display for LineColumn {
     }
 }
 
-#[derive(Clone,Debug,PartialEq,Eq,Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct LineColumnRange {
-    pub start : LineColumn,
-    pub end : Option<LineColumn>,
+    pub start: LineColumn,
+    pub end: Option<LineColumn>,
 }
 
 impl std::fmt::Display for LineColumnRange {


### PR DESCRIPTION
The graph storage registry allows to find optimal implementations and knows the names of the graph storages which are used for serialization. It used an enum and a lot of match patterns and if/else if statements to map the names to the implementations. This was extremely error prone and confusing.

This PR removes the enum and and replaces it with a lazily initialized registry map, where names are mapped to the actual type information. The names are defined by each implementation on its own. The map is created by adding types to it, not names. Also, the decision functions which give the best implementation don't return an enum but a type information. The struct with the type information allows to construct and deserialize the graph storage.