### PR TITLE
Faster and more flexible sort of results in "find" function

### DIFF
--- a/include/graphannis-capi.h
+++ b/include/graphannis-capi.h
@@ -108,6 +108,11 @@ typedef enum {
    * A random ordering which is **not stable**. Each new query will result in a different order.
    */
   Randomized,
+  /*
+   * Results are not ordered at all, but also not actively randomized
+   * Each new query *might* result in a different order.
+   */
+  NotSorted,
 } AnnisResultOrder;
 
 /*

--- a/include/graphannis-capi.h
+++ b/include/graphannis-capi.h
@@ -107,7 +107,7 @@ typedef enum {
   /*
    * A random ordering which is **not stable**. Each new query will result in a different order.
    */
-  Random,
+  Randomized,
 } AnnisResultOrder;
 
 /*

--- a/src/annis/db/corpusstorage.rs
+++ b/src/annis/db/corpusstorage.rs
@@ -1003,7 +1003,11 @@ impl CorpusStorage {
                 }
             };
 
-            quicksort::sort_first_n_items(&mut tmp_results, offset + limit, order_func);
+            if self.query_config.use_parallel_joins {
+                quicksort::sort_first_n_items_parallel(&mut tmp_results, offset + limit, order_func);
+            } else {
+                quicksort::sort_first_n_items(&mut tmp_results, offset + limit, order_func);
+            }
         }
 
         let expected_size = std::cmp::min(tmp_results.len(), limit);

--- a/src/annis/db/corpusstorage.rs
+++ b/src/annis/db/corpusstorage.rs
@@ -1573,10 +1573,6 @@ mod tests {
 
     #[test]
     fn load_cs_twice() {
-        // Init logger to get a trace of the actions that failed
-        simplelog::SimpleLogger::init(log::LevelFilter::Trace, simplelog::Config::default())
-            .unwrap();
-
         if let Ok(tmp) = tempdir::TempDir::new("annis_test") {
             {
                 let mut cs = CorpusStorage::with_auto_cache_size(tmp.path(), false).unwrap();

--- a/src/annis/db/corpusstorage.rs
+++ b/src/annis/db/corpusstorage.rs
@@ -959,8 +959,9 @@ impl CorpusStorage {
             .node_annos
             .get_key_id(&db.get_node_name_key())
             .ok_or("No internal ID for node names found")?;
-
-        let mut tmp_results: Vec<Vec<Match>> = Vec::with_capacity(1024);
+        
+        let estimated_result_size = plan.estimated_output_size();
+        let mut tmp_results: Vec<Vec<Match>> = Vec::with_capacity(estimated_result_size);
 
         for mgroup in plan {
             // add all matches to temporary vector

--- a/src/annis/db/corpusstorage.rs
+++ b/src/annis/db/corpusstorage.rs
@@ -153,7 +153,7 @@ pub enum ResultOrder {
     /// Inverted the order of `Normal`.
     Inverted,
     /// A random ordering which is **not stable**. Each new query will result in a different order.
-    Random,
+    Randomized,
 }
 
 struct PreparationResult<'a> {
@@ -978,7 +978,7 @@ impl CorpusStorage {
                     self.create_node_to_path_cache(&tmp_results, db, node_name_key_id);
 
                 // either sort or randomly shuffle results
-                if order == ResultOrder::Random {
+                if order == ResultOrder::Randomized {
                     let mut rng = rand::thread_rng();
                     rng.shuffle(&mut tmp_results[..])
                 } else {

--- a/src/annis/db/exec/mod.rs
+++ b/src/annis/db/exec/mod.rs
@@ -194,6 +194,10 @@ pub trait ExecutionNode: Iterator {
     fn get_desc(&self) -> Option<&Desc> {
         None
     }
+
+    fn is_sorted_by_text(&self) -> bool {
+        false
+    }
 }
 
 pub struct EmptyResultSet;

--- a/src/annis/db/exec/mod.rs
+++ b/src/annis/db/exec/mod.rs
@@ -223,4 +223,5 @@ pub mod binary_filter;
 pub mod indexjoin;
 pub mod nestedloop;
 pub mod nodesearch;
+pub mod tokensearch;
 pub mod parallel;

--- a/src/annis/db/exec/nodesearch.rs
+++ b/src/annis/db/exec/nodesearch.rs
@@ -1,10 +1,12 @@
 use super::{Desc, ExecutionNode, NodeSearchDesc};
 use annis::db::AnnotationStorage;
+use annis::db::exec::tokensearch::AnyTokenSearch;
 use annis::db::{Graph, Match, ANNIS_NS};
 use annis::errors::*;
 use annis::operator::EdgeAnnoSearchSpec;
 use annis::types::{Component, ComponentType, Edge, LineColumnRange, NodeID};
 use annis::util;
+use annis::db::exec::tokensearch;
 use itertools::Itertools;
 use regex;
 use std;
@@ -58,6 +60,13 @@ impl NodeSearchSpec {
             val: val.map(String::from),
             is_meta,
         }
+    }
+
+    pub fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
+        if let &NodeSearchSpec::AnyToken = &self {
+            return tokensearch::AnyTokenSearch::necessary_components();
+        }
+        vec![]
     }
 }
 
@@ -186,14 +195,10 @@ impl<'a> NodeSearch<'a> {
                 node_nr,
                 location_in_query,
             ),
-            NodeSearchSpec::AnyToken => NodeSearch::new_tokensearch(
+            NodeSearchSpec::AnyToken => NodeSearch::new_anytoken_search(
                 db,
-                None,
-                true,
-                false,
                 &query_fragment,
                 node_nr,
-                location_in_query,
             ),
             NodeSearchSpec::AnyNode => {
                 let type_key = db.get_node_type_key();
@@ -554,6 +559,56 @@ impl<'a> NodeSearch<'a> {
             db.node_annos
                 .number_of_annotations_by_name(Some(tok_key.ns.clone()), tok_key.name.clone())
         };
+        // always assume at least one output item otherwise very small selectivity can fool the planner
+        let est_output = std::cmp::max(1, est_output);
+
+        let const_output = db
+            .node_annos
+            .get_key_id(&db.get_node_type_key())
+            .ok_or("Node type annotation does not exist in database")?;
+
+        Ok(NodeSearch {
+            it: Box::new(it),
+            desc: Some(Desc::empty_with_fragment(
+                &query_fragment,
+                node_nr,
+                Some(est_output),
+            )),
+            node_search_desc: Arc::new(NodeSearchDesc {
+                qname: (Some(tok_key.ns), Some(tok_key.name)),
+                cond: filters,
+                const_output: Some(const_output),
+            }),
+        })
+    }
+
+    fn new_anytoken_search(
+        db: &'a Graph,
+        query_fragment: &str,
+        node_nr: usize,
+    ) -> Result<NodeSearch<'a>> {
+        let tok_key = db.get_token_key();
+        
+        let it: Box<Iterator<Item = Vec<Match>>> = Box::from(AnyTokenSearch::new(db)?);
+        // create filter functions
+        let mut filters: Vec<Box<Fn(&Match) -> bool + Send + Sync>> = Vec::new();
+      
+        let cov_gs = db.get_graphstorage(&Component {
+            ctype: ComponentType::Coverage,
+            layer: String::from(ANNIS_NS),
+            name: String::from(""),
+        });
+        let filter_func: Box<Fn(&Match) -> bool + Send + Sync> = Box::new(move |m| {
+            if let Some(ref cov) = cov_gs {
+                cov.get_outgoing_edges(m.node).next().is_none()
+            } else {
+                true
+            }
+        });
+        filters.push(filter_func);
+    
+        let est_output = db.node_annos
+                .number_of_annotations_by_name(Some(tok_key.ns.clone()), tok_key.name.clone());
         // always assume at least one output item otherwise very small selectivity can fool the planner
         let est_output = std::cmp::max(1, est_output);
 

--- a/src/annis/db/exec/nodesearch.rs
+++ b/src/annis/db/exec/nodesearch.rs
@@ -20,6 +20,7 @@ pub struct NodeSearch<'a> {
 
     desc: Option<Desc>,
     node_search_desc: Arc<NodeSearchDesc>,
+    is_sorted: bool,
 }
 #[derive(Clone, Debug, PartialOrd, Ord, Hash, PartialEq, Eq)]
 pub enum NodeSearchSpec {
@@ -241,6 +242,7 @@ impl<'a> NodeSearch<'a> {
                         cond: vec![filter_func],
                         const_output,
                     }),
+                    is_sorted: false,
                 })
             }
         }
@@ -327,6 +329,7 @@ impl<'a> NodeSearch<'a> {
                 cond: filters,
                 const_output,
             }),
+            is_sorted: false,
         })
     }
 
@@ -426,6 +429,7 @@ impl<'a> NodeSearch<'a> {
                 cond: filters,
                 const_output,
             }),
+            is_sorted: false,
         })
     }
 
@@ -579,6 +583,7 @@ impl<'a> NodeSearch<'a> {
                 cond: filters,
                 const_output: Some(const_output),
             }),
+            is_sorted: false,
         })
     }
 
@@ -629,6 +634,7 @@ impl<'a> NodeSearch<'a> {
                 cond: filters,
                 const_output: Some(const_output),
             }),
+            is_sorted: true,
         })
     }
 
@@ -693,6 +699,7 @@ impl<'a> NodeSearch<'a> {
             it: Box::new(it),
             desc: new_desc,
             node_search_desc,
+            is_sorted: false,
         })
     }
 
@@ -716,6 +723,10 @@ impl<'a> ExecutionNode for NodeSearch<'a> {
 
     fn as_nodesearch(&self) -> Option<&NodeSearch> {
         Some(self)
+    }
+
+    fn is_sorted_by_text(&self) -> bool {
+        self.is_sorted
     }
 }
 

--- a/src/annis/db/exec/tokensearch.rs
+++ b/src/annis/db/exec/tokensearch.rs
@@ -1,21 +1,94 @@
 use annis::db::exec::Desc;
 use annis::db::exec::ExecutionNode;
+use annis::db::graphstorage::GraphStorage;
+use annis::db::sort_matches;
+use annis::db::token_helper::TokenHelper;
 use annis::db::Graph;
 use annis::db::Match;
+use annis::types::AnnoKeyID;
+use annis::types::NodeID;
+use annis::util;
+
 use std::fmt;
+
+use rustc_hash::FxHashMap;
 
 /// An [ExecutionNode](#impl-ExecutionNode) which wraps the search for *all* token in a corpus.
 pub struct TokenSearch<'a> {
     desc: Option<Desc>,
+    node_name_key: AnnoKeyID,
     db: &'a Graph,
+    token_helper: TokenHelper,
+    order_gs: &'a GraphStorage,
+    root_iterators: Option<Vec<Box<Iterator<Item = NodeID> + 'a>>>,
 }
 
 impl<'a> TokenSearch<'a> {
-    pub fn new(db : &'a Graph) -> TokenSearch<'a> {
-
+    pub fn new(
+        db: &'a Graph,
+        token_helper: TokenHelper,
+        order_gs: &'a GraphStorage,
+    ) -> TokenSearch<'a> {
         TokenSearch {
+            order_gs,
+            token_helper,
             db,
             desc: None,
+            node_name_key: db
+                .node_annos
+                .get_key_id(&db.get_node_name_key())
+                .unwrap_or_default(),
+            root_iterators: None,
+        }
+    }
+
+    fn get_root_iterators(&mut self) -> &mut Vec<Box<Iterator<Item = NodeID> + 'a>> {
+        if let Some(ref mut root_iterators) = self.root_iterators {
+            return root_iterators;
+        } else {
+            // iterate over all nodes that are part of the ORDERING component and find the root nodes
+            let mut root_nodes: Vec<Match> = Vec::new();
+            for n in self.order_gs.source_nodes() {
+                if self.order_gs.get_ingoing_edges(n).next() == None {
+                    root_nodes.push(Match {
+                        node: n,
+                        anno_key: self.node_name_key,
+                    });
+                }
+            }
+            // Sort the root nodes by their reverse text position,
+            // so that removing the last item will return the first root node.
+            let mut node_to_path: FxHashMap<NodeID, (Vec<&str>, &str)> = FxHashMap::default();
+            for m in &root_nodes {
+                if let Some(path) = self
+                    .db
+                    .node_annos
+                    .get_value_for_item_by_id(&m.node, self.node_name_key)
+                {
+                    node_to_path.insert(m.node, util::extract_node_path(path));
+                }
+            }
+
+            root_nodes.sort_unstable_by(|a, b| {
+                sort_matches::compare_match_by_text_pos(
+                    b,
+                    a,
+                    &node_to_path,
+                    Some(&self.token_helper),
+                    Some(self.order_gs),
+                )
+            });
+
+            // for root nodes add an iterator for all reachable nodes in the order component
+            let mut root_iterators = Vec::new();
+            for root in root_nodes {
+                let it = self
+                    .order_gs
+                    .find_connected(root.node, 0, std::ops::Bound::Unbounded);
+                root_iterators.push(it);
+            }
+            self.root_iterators = Some(root_iterators);
+            return self.root_iterators.as_mut().unwrap();
         }
     }
 }
@@ -40,6 +113,24 @@ impl<'a> Iterator for TokenSearch<'a> {
     type Item = Vec<Match>;
 
     fn next(&mut self) -> Option<Vec<Match>> {
-        unimplemented!()
+        let node_name_key: AnnoKeyID = self.node_name_key;
+        // lazily initialize the sorted vector of iterators
+        let root_iterators = self.get_root_iterators();
+        // use the last iterator in the list to get the next match
+        while !root_iterators.is_empty() {
+            {
+                let root_iterators_len = root_iterators.len();
+                let it = &mut root_iterators[root_iterators_len - 1];
+                if let Some(n) = it.next() {
+                    return Some(vec![Match {
+                        node: n,
+                        anno_key: node_name_key,
+                    }]);
+                }
+            }
+            root_iterators.pop();
+        }
+
+        None
     }
 }

--- a/src/annis/db/exec/tokensearch.rs
+++ b/src/annis/db/exec/tokensearch.rs
@@ -73,11 +73,11 @@ impl<'a> AnyTokenSearch<'a> {
             ) {
                 let n = tok_candidate.node;
                 let mut is_root_tok = true;
-                if let Some(ref token_helper) = self.token_helper {
-                    is_root_tok = is_root_tok && token_helper.is_token(n);
-                }
                 if let Some(order_gs) = self.order_gs {
                     is_root_tok = is_root_tok && order_gs.get_ingoing_edges(n).next() == None;
+                }
+                if let Some(ref token_helper) = self.token_helper {
+                    is_root_tok = is_root_tok && token_helper.is_token(n);
                 }
                 if is_root_tok {
                     root_nodes.push(Match {

--- a/src/annis/db/exec/tokensearch.rs
+++ b/src/annis/db/exec/tokensearch.rs
@@ -10,11 +10,9 @@ use annis::db::Match;
 use annis::errors::*;
 use annis::types::AnnoKeyID;
 use annis::types::{Component, ComponentType, NodeID};
-use annis::util;
 
 use std::fmt;
 
-use rustc_hash::FxHashMap;
 
 /// An [ExecutionNode](#impl-ExecutionNode) which wraps the search for *all* token in a corpus.
 pub struct AnyTokenSearch<'a> {
@@ -87,24 +85,11 @@ impl<'a> AnyTokenSearch<'a> {
                 }
             
             }
-            // Sort the root nodes by their reverse text position,
-            // so that removing the last item will return the first root node.
-            let mut node_to_path: FxHashMap<NodeID, (Vec<&str>, &str)> = FxHashMap::default();
-            for m in &root_nodes {
-                if let Some(path) = self
-                    .db
-                    .node_annos
-                    .get_value_for_item_by_id(&m.node, self.node_name_key)
-                {
-                    node_to_path.insert(m.node, util::extract_node_path(path));
-                }
-            }
-
             root_nodes.sort_unstable_by(|a, b| {
                 sort_matches::compare_match_by_text_pos(
                     b,
                     a,
-                    &node_to_path,
+                    &self.db.node_annos,
                     self.token_helper.as_ref(),
                     self.order_gs,
                 )

--- a/src/annis/db/exec/tokensearch.rs
+++ b/src/annis/db/exec/tokensearch.rs
@@ -1,0 +1,45 @@
+use annis::db::exec::Desc;
+use annis::db::exec::ExecutionNode;
+use annis::db::Graph;
+use annis::db::Match;
+use std::fmt;
+
+/// An [ExecutionNode](#impl-ExecutionNode) which wraps the search for *all* token in a corpus.
+pub struct TokenSearch<'a> {
+    desc: Option<Desc>,
+    db: &'a Graph,
+}
+
+impl<'a> TokenSearch<'a> {
+    pub fn new(db : &'a Graph) -> TokenSearch<'a> {
+
+        TokenSearch {
+            db,
+            desc: None,
+        }
+    }
+}
+
+impl<'a> fmt::Display for TokenSearch<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "tok")
+    }
+}
+
+impl<'a> ExecutionNode for TokenSearch<'a> {
+    fn as_iter(&mut self) -> &mut Iterator<Item = Vec<Match>> {
+        self
+    }
+
+    fn get_desc(&self) -> Option<&Desc> {
+        self.desc.as_ref()
+    }
+}
+
+impl<'a> Iterator for TokenSearch<'a> {
+    type Item = Vec<Match>;
+
+    fn next(&mut self) -> Option<Vec<Match>> {
+        unimplemented!()
+    }
+}

--- a/src/annis/db/plan.rs
+++ b/src/annis/db/plan.rs
@@ -84,6 +84,16 @@ impl<'a> ExecutionPlan<'a> {
         }
         estimation
     }
+
+    pub fn is_sorted_by_text(&self) -> bool {
+        if self.plans.len() > 1 {
+            false
+        } else if self.plans.is_empty() {
+            true
+        } else {
+            self.plans[0].is_sorted_by_text()
+        }
+    }
 }
 
 impl<'a> std::fmt::Display for ExecutionPlan<'a> {

--- a/src/annis/db/plan.rs
+++ b/src/annis/db/plan.rs
@@ -52,11 +52,14 @@ impl<'a> ExecutionPlan<'a> {
     }
 
     fn reorder_match(&self, tmp: Vec<Match>) -> Vec<Match> {
+        if tmp.len() <= 1 {
+            // nothing to reorder
+            return tmp;
+        }
         if let Some(ref desc) = self.descriptions[self.current_plan] {
             let desc: &Desc = desc;
             // re-order the matched nodes by the original node position of the query
-            let mut result: Vec<Match> = Vec::new();
-            result.reserve(tmp.len());
+            let mut result: Vec<Match> = Vec::with_capacity(tmp.len());
             for i in 0..tmp.len() {
                 if let Some(mapped_pos) = desc.node_pos.get(&i) {
                     result.push(tmp[*mapped_pos].clone());

--- a/src/annis/db/plan.rs
+++ b/src/annis/db/plan.rs
@@ -72,6 +72,18 @@ impl<'a> ExecutionPlan<'a> {
             tmp
         }
     }
+
+    pub fn estimated_output_size(&self) -> usize {
+        let mut estimation = 0;
+        for desc in &self.descriptions {
+            if let Some(desc) = desc {
+                if let Some(ref cost) = desc.cost {
+                    estimation += cost.output;
+                }
+            }
+        }
+        estimation
+    }
 }
 
 impl<'a> std::fmt::Display for ExecutionPlan<'a> {

--- a/src/annis/db/query/conjunction.rs
+++ b/src/annis/db/query/conjunction.rs
@@ -309,6 +309,9 @@ impl<'a> Conjunction<'a> {
             let mut c = op_entry.op.necessary_components(db);
             result.append(&mut c);
         }
+        for n in &self.nodes {
+            result.extend(n.1.necessary_components(db));
+        }
 
         result
     }

--- a/src/annis/db/sort_matches.rs
+++ b/src/annis/db/sort_matches.rs
@@ -24,7 +24,7 @@ pub fn compare_matchgroup_by_text_pos(
     m1.len().cmp(&m2.len())
 }
 
-fn compare_match_by_text_pos(
+pub fn compare_match_by_text_pos(
     m1: &Match,
     m2: &Match,
     node_to_path: &FxHashMap<NodeID, (Vec<&str>, &str)>,
@@ -80,3 +80,4 @@ fn compare_match_by_text_pos(
         m1.node.cmp(&m2.node)
     }
 }
+

--- a/src/annis/db/sort_matches.rs
+++ b/src/annis/db/sort_matches.rs
@@ -12,7 +12,7 @@ pub fn compare_matchgroup_by_text_pos(
     m1: &[Match],
     m2: &[Match],
     db: &Graph,
-    node_to_path: &FxHashMap<NodeID, (Vec<String>, String)>,
+    node_to_path: &FxHashMap<NodeID, (Vec<&str>, &str)>,
 ) -> Ordering {
     for i in 0..std::cmp::min(m1.len(), m2.len()) {
         let element_cmp = compare_match_by_text_pos(&m1[i], &m2[i], db, node_to_path);
@@ -28,7 +28,7 @@ pub fn compare_match_by_text_pos(
     m1: &Match,
     m2: &Match,
     db: &Graph,
-    node_to_path: &FxHashMap<NodeID, (Vec<String>, String)>,
+    node_to_path: &FxHashMap<NodeID, (Vec<&str>, &str)>,
 ) -> Ordering {
     if m1.node == m2.node {
         // same node, use annotation name and namespace to compare

--- a/src/annis/db/sort_matches.rs
+++ b/src/annis/db/sort_matches.rs
@@ -1,21 +1,22 @@
+use annis::db::annostorage::AnnoStorage;
 use annis::db::graphstorage::GraphStorage;
 use annis::db::token_helper::TokenHelper;
 use annis::db::Match;
-use annis::types::NodeID;
-use rustc_hash::FxHashMap;
+use annis::db::{ANNIS_NS, NODE_NAME};
+use annis::types::{AnnoKey, NodeID};
 use std;
 use std::cmp::Ordering;
 
 pub fn compare_matchgroup_by_text_pos(
     m1: &[Match],
     m2: &[Match],
-    node_to_path: &FxHashMap<NodeID, (Vec<&str>, &str)>,
+    node_annos: &AnnoStorage<NodeID>,
     token_helper: Option<&TokenHelper>,
     gs_order: Option<&GraphStorage>,
 ) -> Ordering {
     for i in 0..std::cmp::min(m1.len(), m2.len()) {
         let element_cmp =
-            compare_match_by_text_pos(&m1[i], &m2[i], node_to_path, token_helper, gs_order);
+            compare_match_by_text_pos(&m1[i], &m2[i], node_annos, token_helper, gs_order);
         if element_cmp != Ordering::Equal {
             return element_cmp;
         }
@@ -24,10 +25,48 @@ pub fn compare_matchgroup_by_text_pos(
     m1.len().cmp(&m2.len())
 }
 
+fn split_path_and_nodename(full_node_name: &str) -> (&str, &str) {
+    let hash_pos = full_node_name.rfind('#');
+    let path: &str = &full_node_name[0..hash_pos.unwrap_or_else(|| full_node_name.len())];
+
+    if let Some(hash_pos) = hash_pos {
+        (path, &full_node_name[hash_pos + 1..])
+    } else {
+        (path, "")
+    }
+}
+
+fn compare_document_path(p1: &str, p2: &str) -> std::cmp::Ordering {
+    let it1 = p1.split('/').filter(|s| !s.is_empty());
+    let it2 = p2.split('/').filter(|s| !s.is_empty());
+
+    for (part1, part2) in it1.zip(it2) {
+        if part1 < part2 {
+            return std::cmp::Ordering::Less;
+        } else if part1 > part2 {
+            return std::cmp::Ordering::Greater;
+        }
+    }
+
+    // Both paths have the same prefix, check if one of them has more elements.
+    // TODO: Since both iterators have been moved, they have to be recreated, there
+    // should be a more efficient way of doing this.
+    let length1 = p1.split('/').filter(|s| !s.is_empty()).count();
+    let length2 = p2.split('/').filter(|s| !s.is_empty()).count();
+    length1.cmp(&length2)
+}
+
+lazy_static! {
+    static ref node_name_key: AnnoKey = AnnoKey {
+        ns: ANNIS_NS.to_string(),
+        name: NODE_NAME.to_string(),
+    };
+}
+
 pub fn compare_match_by_text_pos(
     m1: &Match,
     m2: &Match,
-    node_to_path: &FxHashMap<NodeID, (Vec<&str>, &str)>,
+    node_annos: &AnnoStorage<NodeID>,
     token_helper: Option<&TokenHelper>,
     gs_order: Option<&GraphStorage>,
 ) -> Ordering {
@@ -36,11 +75,15 @@ pub fn compare_match_by_text_pos(
         m1.anno_key.cmp(&m2.anno_key)
     } else {
         // get the node paths and names
-        let m1_entry = node_to_path.get(&m1.node);
-        let m2_entry = node_to_path.get(&m2.node);
-        if let (Some((m1_path, m1_name)), Some((m2_path, m2_name))) = (m1_entry, m2_entry) {
+        let m1_anno_val = node_annos.get_value_for_item(&m1.node, &node_name_key);
+        let m2_anno_val = node_annos.get_value_for_item(&m2.node, &node_name_key);
+
+        if let (Some(m1_anno_val), Some(m2_anno_val)) = (m1_anno_val, m2_anno_val) {
+            let (m1_path, m1_name) = split_path_and_nodename(m1_anno_val);
+            let (m2_path, m2_name) = split_path_and_nodename(m2_anno_val);
+
             // 1. compare the path
-            let path_cmp = m1_path.cmp(&m2_path);
+            let path_cmp = compare_document_path(m1_path, m2_path);
             if path_cmp != Ordering::Equal {
                 return path_cmp;
             }
@@ -80,4 +123,3 @@ pub fn compare_match_by_text_pos(
         m1.node.cmp(&m2.node)
     }
 }
-

--- a/src/annis/util/mod.rs
+++ b/src/annis/util/mod.rs
@@ -48,23 +48,22 @@ pub fn contains_regex_metacharacters(pattern: &str) -> bool {
 /// assert_eq!(name, "");
 /// assert_eq!(path, vec!["toplevel", "subcorpus1", "subcorpus2", "doc1"]);
 /// ```
-pub fn extract_node_path(full_node_name: &str) -> (Vec<String>, String) {
+pub fn extract_node_path(full_node_name: &str) -> (Vec<&str>, &str) {
     // separate path and name first
     let hash_pos = full_node_name.rfind('#');
 
     let path_str: &str = &full_node_name[0..hash_pos.unwrap_or_else(|| full_node_name.len())];
-    let mut path: Vec<String> = Vec::with_capacity(4);
+    let mut path: Vec<&str> = Vec::with_capacity(4);
     path.extend(
         path_str
             .split('/')
             .filter(|s| !s.is_empty())
-            .map(|s| s.to_owned()),
     );
 
     if let Some(hash_pos) = hash_pos {
-        return (path, full_node_name[hash_pos + 1..].to_owned());
+        return (path, &full_node_name[hash_pos + 1..]);
     } else {
-        return (path, "".to_owned());
+        return (path, "");
     }
 }
 

--- a/src/annis/util/mod.rs
+++ b/src/annis/util/mod.rs
@@ -54,7 +54,8 @@ pub fn extract_node_path(full_node_name: &str) -> (Vec<&str>, &str) {
     let hash_pos = full_node_name.rfind('#');
 
     let path_str: &str = &full_node_name[0..hash_pos.unwrap_or_else(|| full_node_name.len())];
-    let path: Vec<&str> = path_str.split('/').filter(|s| !s.is_empty()).collect();
+    let mut path: Vec<&str> = Vec::with_capacity(4);
+    path.extend(path_str.split('/').filter(|s| !s.is_empty()));
     if let Some(hash_pos) = hash_pos {
         return (path, &full_node_name[hash_pos + 1..]);
     } else {

--- a/src/annis/util/mod.rs
+++ b/src/annis/util/mod.rs
@@ -53,13 +53,7 @@ pub fn extract_node_path(full_node_name: &str) -> (Vec<&str>, &str) {
     let hash_pos = full_node_name.rfind('#');
 
     let path_str: &str = &full_node_name[0..hash_pos.unwrap_or_else(|| full_node_name.len())];
-    let mut path: Vec<&str> = Vec::with_capacity(4);
-    path.extend(
-        path_str
-            .split('/')
-            .filter(|s| !s.is_empty())
-    );
-
+    let path: Vec<&str> = path_str.split('/').filter(|s| !s.is_empty()).collect();
     if let Some(hash_pos) = hash_pos {
         return (path, &full_node_name[hash_pos + 1..]);
     } else {
@@ -123,7 +117,7 @@ impl SearchDef {
 
 /// Returns an iterator over all query definitions of a folder.
 /// - `folder` - The folder on the file system.
-/// - `panic_on_invalid` - If true, an invalid query definition will trigger a panic, otherwise it will be ignored. 
+/// - `panic_on_invalid` - If true, an invalid query definition will trigger a panic, otherwise it will be ignored.
 /// Can be used if this query is called in a test case to fail the test.
 pub fn get_queries_from_folder(
     folder: &Path,

--- a/src/annis/util/mod.rs
+++ b/src/annis/util/mod.rs
@@ -26,43 +26,6 @@ pub fn contains_regex_metacharacters(pattern: &str) -> bool {
     false
 }
 
-/// Takes a node name/ID and extracts both the document path as array and the node name itself.
-///
-/// Complete node names/IDs have the form `toplevel-corpus/sub-corpus/.../document#node-name`,
-/// mimicking simple URIs (without a scheme) and a limited set of allowed characters as corpus/document names.
-/// The part before the fragment is returned as vector, the latter one as string.
-///
-/// # Examples
-/// ```
-/// extern crate graphannis;
-/// use graphannis::util;
-///
-/// let full_node_name = "toplevel/subcorpus1/subcorpus2/doc1#mynode";
-/// let (path, name) = util::extract_node_path(full_node_name);
-///
-/// assert_eq!(name, "mynode");
-/// assert_eq!(path, vec!["toplevel", "subcorpus1", "subcorpus2", "doc1"]);
-///
-/// let full_doc_name = "toplevel/subcorpus1/subcorpus2/doc1";
-/// let (path, name) = util::extract_node_path(full_doc_name);
-///
-/// assert_eq!(name, "");
-/// assert_eq!(path, vec!["toplevel", "subcorpus1", "subcorpus2", "doc1"]);
-/// ```
-pub fn extract_node_path(full_node_name: &str) -> (Vec<&str>, &str) {
-    // separate path and name first
-    let hash_pos = full_node_name.rfind('#');
-
-    let path_str: &str = &full_node_name[0..hash_pos.unwrap_or_else(|| full_node_name.len())];
-    let mut path: Vec<&str> = Vec::with_capacity(4);
-    path.extend(path_str.split('/').filter(|s| !s.is_empty()));
-    if let Some(hash_pos) = hash_pos {
-        return (path, &full_node_name[hash_pos + 1..]);
-    } else {
-        return (path, "");
-    }
-}
-
 pub fn split_qname(qname: &str) -> (Option<&str>, &str) {
     let sep_pos = qname.find("::.+");
     if let Some(sep_pos) = sep_pos {

--- a/src/annis/util/mod.rs
+++ b/src/annis/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod memory_estimation;
+pub mod quicksort;
 
 use regex_syntax;
 use std;

--- a/src/annis/util/quicksort.rs
+++ b/src/annis/util/quicksort.rs
@@ -11,7 +11,7 @@ where
 {
     let item_len = items.len();
     if item_len > 0 {
-        quicksort(items, 0, item_len - 1, n, &order_func);
+        quicksort(items, n, &order_func);
     }
 }
 
@@ -24,41 +24,47 @@ where
 /// The algorithm used a randomized pivot element.
 fn quicksort<T, F>(
     items: &mut [T],
-    p: usize,
-    r: usize,
     max_size: usize,
     order_func: &F,
 ) where
     F: Fn(&T, &T) -> std::cmp::Ordering,
 {
-    if p < r {
-        let q = randomized_partition(items, p, r, order_func);
+    if items.len() > 1 {
+        let q = randomized_partition(items, order_func);
         if q > 0 {
-            quicksort(items, p, q - 1, max_size, order_func);
+            quicksort(&mut items[0..q], max_size, order_func);
         }
-        if (q - p) < max_size {
+        if q < max_size {
             // only sort right partition if the left partition is not large enough
-            quicksort(items, q + 1, r, max_size, order_func);
+            quicksort(&mut items[(q + 1)..], max_size, order_func);
         }
     }
 }
 
-fn randomized_partition<T, F>(items: &mut [T], p: usize, r: usize, order_func: &F) -> usize
+fn randomized_partition<T, F>(items: &mut [T], order_func: &F) -> usize
 where
     F: Fn(&T, &T) -> std::cmp::Ordering,
 {
-    let mut rng = rand::thread_rng();
-    let i = rng.gen_range(p, r+1);
-    items.swap(r, i);
-    partition(items, p, r, order_func)
+    let items_len = items.len();
+    if items_len == 0 {
+        0
+    } else {
+        let mut rng = rand::thread_rng();
+        let i = rng.gen_range(0, items_len);
+        items.swap(items_len-1, i);
+        partition(items, order_func)
+    }
 }
 
-fn partition<T, F>(items: &mut [T], p: usize, r: usize, order_func: &F) -> usize
+fn partition<T, F>(items: &mut [T], order_func: &F) -> usize
 where
     F: Fn(&T, &T) -> std::cmp::Ordering,
 {
-    let mut i = p;
-    for j in p..r {
+    let r = items.len()-1;
+
+    let mut i = 0;
+
+    for j in 0..(items.len()-1) {
         let comparision = order_func(&items[j], &items[r]);
         match comparision {
             std::cmp::Ordering::Less | std::cmp::Ordering::Equal => {

--- a/src/annis/util/quicksort.rs
+++ b/src/annis/util/quicksort.rs
@@ -1,0 +1,65 @@
+use std;
+
+pub fn sort_first_n_items<T, F>(items: &mut Vec<T>, n: usize, order_func: F)
+where
+    F: Fn(&T, &T) -> std::cmp::Ordering,
+{
+    let item_len = items.len();
+    quicksort(items, 0, item_len - 1, n, &order_func);
+}
+
+fn quicksort<T, F>(items: &mut Vec<T>, p: usize, r: usize, max_size: usize, order_func: &F)
+where
+    F: Fn(&T, &T) -> std::cmp::Ordering,
+{
+    if p < r {
+        let q = partition(items, p, r, order_func);
+        quicksort(items, p, q - 1, max_size, order_func);
+        if (q-p) < max_size { 
+            // only sort right partition if the left partition is not large enough
+            quicksort(items, q + 1, r, max_size, order_func);
+        }
+    }
+}
+
+fn partition<T, F>(items: &mut Vec<T>, p: usize, r: usize, order_func: &F) -> usize
+where
+    F: Fn(&T, &T) -> std::cmp::Ordering,
+{
+    let mut i = if p == 0 { None } else { Some(p - 1) };
+    for j in p..r {
+        let comparision = order_func(&items[j], &items[r]);
+        match comparision {
+            std::cmp::Ordering::Less | std::cmp::Ordering::Equal => {
+                i = if let Some(i) = i {
+                    Some(i + 1)
+                } else {
+                    Some(0)
+                };
+                items.swap(i.unwrap(), j);
+            }
+            _ => {}
+        }
+    }
+    i = if let Some(i) = i {
+        Some(i + 1)
+    } else {
+        Some(0)
+    };
+
+    items.swap(i.unwrap(), r);
+
+    i.unwrap()
+}
+
+#[cfg(test)]
+mod test {
+
+    #[test]
+    fn canary_sort_test() {
+        let mut items = vec![4, 10, 100, 4, 5];
+        let num_items = items.len();
+        super::sort_first_n_items(&mut items, num_items, |x, y| x.cmp(y));
+        assert_eq!(vec![4, 4, 5, 10, 100], items);
+    }
+}

--- a/src/annis/util/quicksort.rs
+++ b/src/annis/util/quicksort.rs
@@ -1,5 +1,10 @@
+use rand::Rng;
 use std;
 
+/// Make sure that the first `n` items of the complete vector are sorted by the given comparision function.
+/// 
+/// This returns the original items and it is guaranteed that the items (0..n) are
+/// sorted and that all of these items are smaller or equal to the n-th item.
 pub fn sort_first_n_items<T, F>(items: &mut Vec<T>, n: usize, order_func: F)
 where
     F: Fn(&T, &T) -> std::cmp::Ordering,
@@ -10,20 +15,42 @@ where
     }
 }
 
-fn quicksort<T, F>(items: &mut Vec<T>, p: usize, r: usize, max_size: usize, order_func: &F)
-where
+/// Classic implementation of a quicksort algorithm, see Cormen et al. 2009 "Introduction to Algorithms" p. 170ff
+/// for the specific algorithm used as a base here.
+///
+/// The algorithm has been modified to accept a `max_size` parameter which allows to abort the algorithm
+/// if at least `max_size` items at the beginning of the vector have been sorted.
+///
+/// The algorithm used a randomized pivot element.
+fn quicksort<T, F>(
+    items: &mut Vec<T>,
+    p: usize,
+    r: usize,
+    max_size: usize,
+    order_func: &F,
+) where
     F: Fn(&T, &T) -> std::cmp::Ordering,
 {
     if p < r {
-        let q = partition(items, p, r, order_func);
+        let q = randomized_partition(items, p, r, order_func);
         if q > 0 {
             quicksort(items, p, q - 1, max_size, order_func);
         }
-        if (q-p) < max_size { 
+        if (q - p) < max_size {
             // only sort right partition if the left partition is not large enough
             quicksort(items, q + 1, r, max_size, order_func);
         }
     }
+}
+
+fn randomized_partition<T, F>(items: &mut Vec<T>, p: usize, r: usize, order_func: &F) -> usize
+where
+    F: Fn(&T, &T) -> std::cmp::Ordering,
+{
+    let mut rng = rand::thread_rng();
+    let i = rng.gen_range(p, r+1);
+    items.swap(r, i);
+    partition(items, p, r, order_func)
 }
 
 fn partition<T, F>(items: &mut Vec<T>, p: usize, r: usize, order_func: &F) -> usize
@@ -50,8 +77,8 @@ where
 #[cfg(test)]
 mod test {
 
+    use rand::distributions::{Distribution, Range};
     use rand::Rng;
-    use rand::distributions::{Range, Distribution};
 
     #[test]
     fn canary_sort_test() {
@@ -60,27 +87,29 @@ mod test {
         super::sort_first_n_items(&mut items, num_items, |x, y| x.cmp(y));
         assert_eq!(vec![4, 4, 5, 10, 100], items);
 
-        let mut items : Vec<usize> = vec![];
+        let mut items: Vec<usize> = vec![];
         super::sort_first_n_items(&mut items, 0, |x, y| x.cmp(y));
-        let empty_items : Vec<usize> = vec![];
+        let empty_items: Vec<usize> = vec![];
         assert_eq!(empty_items, items);
 
-        let mut items : Vec<usize> = vec![1];
+        let mut items: Vec<usize> = vec![1];
         super::sort_first_n_items(&mut items, 0, |x, y| x.cmp(y));
         assert_eq!(vec![1], items);
 
-        let mut items : Vec<usize> = vec![1,2];
+        let mut items: Vec<usize> = vec![1, 2];
         super::sort_first_n_items(&mut items, 0, |x, y| x.cmp(y));
-        assert_eq!(vec![1,2], items);
+        assert_eq!(vec![1, 2], items);
 
-        let mut items : Vec<usize> = vec![2,1];
+        let mut items: Vec<usize> = vec![2, 1];
         super::sort_first_n_items(&mut items, 0, |x, y| x.cmp(y));
-        assert_eq!(vec![1,2], items);
+        assert_eq!(vec![1, 2], items);
 
-        let mut items : Vec<usize> = vec![1,2,3,4,5];
+        let mut items: Vec<usize> = vec![1, 2, 3, 4, 5];
         super::sort_first_n_items(&mut items, 0, |x, y| x.cmp(y));
-        assert_eq!(vec![1,2,3,4,5], items);
+        assert_eq!(vec![1, 2, 3, 4, 5], items);
     }
+
+    
 
     #[test]
     fn random_sort_test() {
@@ -101,6 +130,5 @@ mod test {
             super::sort_first_n_items(&mut items, items_size, |x, y| x.cmp(y));
             assert_eq!(items, sorted_by_stdlib);
         }
-
     }
 }

--- a/src/annis/util/quicksort.rs
+++ b/src/annis/util/quicksort.rs
@@ -23,7 +23,7 @@ where
 ///
 /// The algorithm used a randomized pivot element.
 fn quicksort<T, F>(
-    items: &mut Vec<T>,
+    items: &mut [T],
     p: usize,
     r: usize,
     max_size: usize,
@@ -43,7 +43,7 @@ fn quicksort<T, F>(
     }
 }
 
-fn randomized_partition<T, F>(items: &mut Vec<T>, p: usize, r: usize, order_func: &F) -> usize
+fn randomized_partition<T, F>(items: &mut [T], p: usize, r: usize, order_func: &F) -> usize
 where
     F: Fn(&T, &T) -> std::cmp::Ordering,
 {
@@ -53,7 +53,7 @@ where
     partition(items, p, r, order_func)
 }
 
-fn partition<T, F>(items: &mut Vec<T>, p: usize, r: usize, order_func: &F) -> usize
+fn partition<T, F>(items: &mut [T], p: usize, r: usize, order_func: &F) -> usize
 where
     F: Fn(&T, &T) -> std::cmp::Ordering,
 {

--- a/src/annis/util/quicksort.rs
+++ b/src/annis/util/quicksort.rs
@@ -1,13 +1,15 @@
 use rand::Rng;
+use rayon;
 use std;
 
 /// Make sure that the first `n` items of the complete vector are sorted by the given comparision function.
-/// 
+///
 /// This returns the original items and it is guaranteed that the items (0..n) are
 /// sorted and that all of these items are smaller or equal to the n-th item.
 pub fn sort_first_n_items<T, F>(items: &mut Vec<T>, n: usize, order_func: F)
 where
-    F: Fn(&T, &T) -> std::cmp::Ordering,
+    T: Send,
+    F: Fn(&T, &T) -> std::cmp::Ordering +  Sync,
 {
     let item_len = items.len();
     if item_len > 0 {
@@ -21,23 +23,63 @@ where
 /// The algorithm has been modified to accept a `max_size` parameter which allows to abort the algorithm
 /// if at least `max_size` items at the beginning of the vector have been sorted.
 ///
-/// The algorithm used a randomized pivot element.
-fn quicksort<T, F>(
-    items: &mut [T],
-    max_size: usize,
-    order_func: &F,
-) where
-    F: Fn(&T, &T) -> std::cmp::Ordering,
+/// The algorithm used a randomized pivot element and is executed in parallel.
+fn quicksort<T, F>(items: &mut [T], max_size: usize, order_func: &F)
+where
+    F: Fn(&T, &T) -> std::cmp::Ordering
 {
     if items.len() > 1 {
         let q = randomized_partition(items, order_func);
-        if q > 0 {
-            quicksort(&mut items[0..q], max_size, order_func);
-        }
+        let (lo, hi) = items.split_at_mut(q);
+
+        quicksort(lo, max_size, order_func);
         if q < max_size {
             // only sort right partition if the left partition is not large enough
-            quicksort(&mut items[(q + 1)..], max_size, order_func);
+            quicksort(hi, max_size, order_func);
         }
+    }
+}
+
+/// Make sure that the first `n` items of the complete vector are sorted by the given comparision function.
+///
+/// This returns the original items and it is guaranteed that the items (0..n) are
+/// sorted and that all of these items are smaller or equal to the n-th item.
+pub fn sort_first_n_items_parallel<T, F>(items: &mut Vec<T>, n: usize, order_func: F)
+where
+    T: Send,
+    F: Fn(&T, &T) -> std::cmp::Ordering +  Sync,
+{
+    let item_len = items.len();
+    if item_len > 0 {
+        quicksort_parallel(items, n, &order_func);
+    }
+}
+
+/// Classic implementation of a quicksort algorithm, see Cormen et al. 2009 "Introduction to Algorithms" p. 170ff
+/// for the specific algorithm used as a base here.
+///
+/// The algorithm has been modified to accept a `max_size` parameter which allows to abort the algorithm
+/// if at least `max_size` items at the beginning of the vector have been sorted.
+///
+/// The algorithm used a randomized pivot element and is executed in parallel.
+fn quicksort_parallel<T, F>(items: &mut [T], max_size: usize, order_func: &F)
+where
+    T: Send,
+    F: Fn(&T, &T) -> std::cmp::Ordering + Sync
+{
+    if items.len() > 1 {
+        let q = randomized_partition(items, order_func);
+        let (lo, hi) = items.split_at_mut(q);
+
+        rayon::join(
+            || quicksort_parallel(lo, max_size, order_func),
+            || {
+                if q < max_size {
+                    // only sort right partition if the left partition is not large enough
+                    quicksort_parallel(hi, max_size, order_func);
+                }
+            },
+        );
     }
 }
 
@@ -51,7 +93,7 @@ where
     } else {
         let mut rng = rand::thread_rng();
         let i = rng.gen_range(0, items_len);
-        items.swap(items_len-1, i);
+        items.swap(items_len - 1, i);
         partition(items, order_func)
     }
 }
@@ -60,16 +102,16 @@ fn partition<T, F>(items: &mut [T], order_func: &F) -> usize
 where
     F: Fn(&T, &T) -> std::cmp::Ordering,
 {
-    let r = items.len()-1;
+    let r = items.len() - 1;
 
     let mut i = 0;
 
-    for j in 0..(items.len()-1) {
+    for j in 0..(items.len() - 1) {
         let comparision = order_func(&items[j], &items[r]);
         match comparision {
             std::cmp::Ordering::Less | std::cmp::Ordering::Equal => {
                 items.swap(i, j);
-                i = i + 1;
+                i += 1;
             }
             _ => {}
         }
@@ -115,7 +157,34 @@ mod test {
         assert_eq!(vec![1, 2, 3, 4, 5], items);
     }
 
-    
+    #[test]
+    fn canary_sort_test_parallel() {
+        let mut items = vec![4, 10, 100, 4, 5];
+        let num_items = items.len();
+        super::sort_first_n_items_parallel(&mut items, num_items, |x, y| x.cmp(y));
+        assert_eq!(vec![4, 4, 5, 10, 100], items);
+
+        let mut items: Vec<usize> = vec![];
+        super::sort_first_n_items_parallel(&mut items, 0, |x, y| x.cmp(y));
+        let empty_items: Vec<usize> = vec![];
+        assert_eq!(empty_items, items);
+
+        let mut items: Vec<usize> = vec![1];
+        super::sort_first_n_items_parallel(&mut items, 0, |x, y| x.cmp(y));
+        assert_eq!(vec![1], items);
+
+        let mut items: Vec<usize> = vec![1, 2];
+        super::sort_first_n_items_parallel(&mut items, 0, |x, y| x.cmp(y));
+        assert_eq!(vec![1, 2], items);
+
+        let mut items: Vec<usize> = vec![2, 1];
+        super::sort_first_n_items_parallel(&mut items, 0, |x, y| x.cmp(y));
+        assert_eq!(vec![1, 2], items);
+
+        let mut items: Vec<usize> = vec![1, 2, 3, 4, 5];
+        super::sort_first_n_items_parallel(&mut items, 0, |x, y| x.cmp(y));
+        assert_eq!(vec![1, 2, 3, 4, 5], items);
+    }
 
     #[test]
     fn random_sort_test() {
@@ -134,6 +203,27 @@ mod test {
             let mut sorted_by_stdlib = items.clone();
             sorted_by_stdlib.sort();
             super::sort_first_n_items(&mut items, items_size, |x, y| x.cmp(y));
+            assert_eq!(items, sorted_by_stdlib);
+        }
+    }
+
+    #[test]
+    fn random_sort_test_parallel() {
+        // compare 100 random arrays against the standard library sort
+        let mut rng = rand::thread_rng();
+        let random_item_gen = Range::new(1, 100);
+
+        for _i in 0..100 {
+            // the arrays should have a size from 10 to 50
+            let items_size = rng.gen_range(10, 51);
+            let mut items = Vec::with_capacity(items_size);
+            for _j in 0..items_size {
+                items.push(random_item_gen.sample(&mut rng));
+            }
+
+            let mut sorted_by_stdlib = items.clone();
+            sorted_by_stdlib.sort();
+            super::sort_first_n_items_parallel(&mut items, items_size, |x, y| x.cmp(y));
             assert_eq!(items, sorted_by_stdlib);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,6 @@ pub mod errors {
 
 /// Utility functions.
 pub mod util {
-    pub use annis::util::extract_node_path;
     pub use annis::util::get_queries_from_folder;
     pub use annis::util::SearchDef;
 }


### PR DESCRIPTION
This implements several improvements to speedup sorting of the result set:
- abort quick sort for the right side of the partition if the left side is already large enough for the given limit/offset values
- remove the necessity to sort `tok` (any token) searches
- add option to not sort the result at all (can be used e.g. as a fallback by the frontend) 
- don't allocate a lot of small vectors for the path array, but compare the string references directly